### PR TITLE
Reduce OkHttp exposure, enhance endpoint definition

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -36,7 +36,7 @@ To access the API of a Mastodon server, we first need to create client credentia
 __Kotlin__
 
 ```kotlin
-val client: MastodonClient = MastodonClient.Builder(instanceHostname, OkHttpClient.Builder(), Gson()).build()
+val client: MastodonClient = MastodonClient.Builder(instanceHostname, Gson()).build()
 val apps = Apps(client)
 val appRegistration = apps.createApp(
 	clientName = "mastodon4j-sample-app",
@@ -49,7 +49,7 @@ val appRegistration = apps.createApp(
 __Java__
 
 ```java
-MastodonClient client = new MastodonClient.Builder(instanceHostname, new OkHttpClient.Builder(), new Gson()).build();
+MastodonClient client = new MastodonClient.Builder(instanceHostname, new Gson()).build();
 Apps apps = new Apps(client);
 try {
 	AppRegistration appRegistration = apps.createApp(
@@ -102,7 +102,7 @@ __Kotlin__
 
 ```kotlin
 // creating a new client using previously received access token
-val client: MastodonClient = MastodonClient.Builder(instanceHostname, OkHttpClient.Builder(), Gson())
+val client: MastodonClient = MastodonClient.Builder(instanceHostname, Gson())
 	.accessToken(accessToken)
 	.build()
 
@@ -189,7 +189,7 @@ v1.0.0 or later
 __Kotlin__
 
 ```kotlin
-val client: MastodonClient = MastodonClient.Builder(instanceHostname, OkHttpClient.Builder(), Gson())
+val client: MastodonClient = MastodonClient.Builder(instanceHostname, Gson())
   .accessToken(accessToken)
   .useStreamingApi()
   .build()
@@ -215,7 +215,7 @@ try {
 __Java__
 
 ```java
-MastodonClient client = new MastodonClient.Builder(instanceHostname, new OkHttpClient.Builder(), new Gson())
+MastodonClient client = new MastodonClient.Builder(instanceHostname, new Gson())
         .accessToken(accessToken)
         .useStreamingApi()
         .build();

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
@@ -154,7 +154,7 @@ private constructor(
                 .addEncodedPathSegments(path)
 
             query?.let {
-                urlBuilder.encodedQuery(it.toString())
+                urlBuilder.encodedQuery(it.build())
             }
 
             return urlBuilder.build()

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
@@ -3,13 +3,9 @@ package com.sys1yagi.mastodon4j
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
 import com.sys1yagi.mastodon4j.extension.emptyRequestBody
-import okhttp3.Interceptor
+import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -20,7 +16,7 @@ private constructor(
     private val gson: Gson
 ) {
     private var debug = false
-    private val baseUrl = "https://${instanceName}/api/v1"
+    private val baseUrl = "https://${instanceName}"
 
     private fun debugPrint(log: String) {
         if (debug) {
@@ -76,29 +72,8 @@ private constructor(
      *
      * @see post
      */
-    open fun postRequestBody(path: String, body: RequestBody) =
-        postUrlRequestBody("$baseUrl/$path", body)
-
-    /**
-     * Get a response from the Mastodon instance defined for this client using the POST method.
-     * @param url a full URL to the API endpoint to call
-     * @param parameters the parameters to use for this request; may be null
-     */
-    open fun postUrl(url: String, parameters: Parameter): Response {
-        val parameterBody = parameters
-            .build()
-            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-        return postUrlRequestBody(url, parameterBody)
-    }
-
-    /**
-     * Get a response from the Mastodon instance defined for this client using the POST method.
-     * @param url a full URL to the API endpoint to call
-     * @param body the RequestBody to use for this request
-     *
-     * @see postUrl
-     */
-    private fun postUrlRequestBody(url: String, body: RequestBody): Response {
+    open fun postRequestBody(path: String, body: RequestBody): Response {
+        val url = "$baseUrl/$path"
         try {
             debugPrint(url)
             val call = client.newCall(

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
@@ -160,9 +160,9 @@ private constructor(
     }
 
     class Builder(private val instanceName: String,
-                  private val okHttpClientBuilder: OkHttpClient.Builder,
                   private val gson: Gson) {
 
+        private val okHttpClientBuilder = OkHttpClient.Builder()
         private var accessToken: String? = null
         private var debug = false
 

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
@@ -3,9 +3,14 @@ package com.sys1yagi.mastodon4j
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
 import com.sys1yagi.mastodon4j.extension.emptyRequestBody
-import okhttp3.*
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -42,9 +47,8 @@ private constructor(
      * @param path an absolute path to the API endpoint to call
      * @param parameters the parameters to use in the request body for this request; may be null
      */
-    open fun post(path: String, parameters: Parameter? = null): Response {
-        return postRequestBody(path, parameterBody(parameters))
-    }
+    open fun post(path: String, parameters: Parameter? = null): Response =
+        postRequestBody(path, parameterBody(parameters))
 
     /**
      * Get a response from the Mastodon instance defined for this client using the POST method. Use this method if
@@ -162,7 +166,8 @@ private constructor(
 
         fun parameterBody(parameters: Parameter?): RequestBody {
             return parameters
-                ?.build()?.toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+                ?.build()
+                ?.toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
                 ?: emptyRequestBody()
         }
     }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/MastodonClient.kt
@@ -2,22 +2,162 @@ package com.sys1yagi.mastodon4j
 
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
+import com.sys1yagi.mastodon4j.extension.emptyRequestBody
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 open class MastodonClient
 private constructor(
-        private val instanceName: String,
-        private val client: OkHttpClient,
-        private val gson: Gson
+    private val instanceName: String,
+    private val client: OkHttpClient,
+    private val gson: Gson
 ) {
     private var debug = false
-    val baseUrl = "https://${instanceName}/api/v1"
+    private val baseUrl = "https://${instanceName}/api/v1"
+
+    private fun debugPrint(log: String) {
+        if (debug) {
+            println(log)
+        }
+    }
+
+    open fun getSerializer() = gson
+
+    open fun getInstanceName() = instanceName
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the GET method.
+     * @param path an absolute path to the API endpoint to call
+     * @param parameters the parameters to use for this request; may be null
+     */
+    open fun get(path: String, parameters: Parameter? = null): Response {
+        try {
+            val url = "$baseUrl/$path"
+            debugPrint(url)
+            val urlWithParams = parameters?.let {
+                "$url?${it.build()}"
+            } ?: url
+            val call = client.newCall(
+                Request.Builder()
+                    .url(urlWithParams)
+                    .get()
+                    .build())
+            return call.execute()
+        } catch (e: IOException) {
+            throw Mastodon4jRequestException(e)
+        }
+    }
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the POST method.
+     * @param path an absolute path to the API endpoint to call
+     * @param parameters the parameters to use for this request; may be null
+     */
+    open fun post(path: String, parameters: Parameter? = null): Response {
+        val parameterBody = parameters
+            ?.build()?.toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+            ?: emptyRequestBody()
+
+        return postRequestBody(path, parameterBody)
+    }
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the POST method. Use this method if
+     * you need to build your own RequestBody; see post() otherwise.
+     * @param path an absolute path to the API endpoint to call
+     * @param body the RequestBody to use for this request
+     *
+     * @see post
+     */
+    open fun postRequestBody(path: String, body: RequestBody) =
+        postUrlRequestBody("$baseUrl/$path", body)
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the POST method.
+     * @param url a full URL to the API endpoint to call
+     * @param parameters the parameters to use for this request; may be null
+     */
+    open fun postUrl(url: String, parameters: Parameter): Response {
+        val parameterBody = parameters
+            .build()
+            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+        return postUrlRequestBody(url, parameterBody)
+    }
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the POST method.
+     * @param url a full URL to the API endpoint to call
+     * @param body the RequestBody to use for this request
+     *
+     * @see postUrl
+     */
+    private fun postUrlRequestBody(url: String, body: RequestBody): Response {
+        try {
+            debugPrint(url)
+            val call = client.newCall(
+                Request.Builder()
+                    .url(url)
+                    .post(body)
+                    .build())
+            return call.execute()
+        } catch (e: IllegalArgumentException) {
+            throw Mastodon4jRequestException(e)
+        } catch (e: IOException) {
+            throw Mastodon4jRequestException(e)
+        }
+    }
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the PATCH method.
+     * @param path an absolute path to the API endpoint to call
+     * @param parameters the parameters to use for this request
+     */
+    open fun patch(path: String, parameters: Parameter): Response {
+        val parameterBody = parameters
+            .build()
+            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+
+        try {
+            val url = "$baseUrl/$path"
+            debugPrint(url)
+            val call = client.newCall(
+                Request.Builder()
+                    .url(url)
+                    .patch(parameterBody)
+                    .build()
+            )
+            return call.execute()
+        } catch (e: IOException) {
+            throw Mastodon4jRequestException(e)
+        }
+    }
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the DELETE method.
+     * @param path an absolute path to the API endpoint to call
+     */
+    open fun delete(path: String): Response {
+        try {
+            val url = "$baseUrl/$path"
+            debugPrint(url)
+            val call = client.newCall(
+                Request.Builder()
+                    .url(url)
+                    .delete()
+                    .build()
+            )
+            return call.execute()
+        } catch (e: IOException) {
+            throw Mastodon4jRequestException(e)
+        }
+    }
 
     class Builder(private val instanceName: String,
                   private val okHttpClientBuilder: OkHttpClient.Builder,
@@ -40,18 +180,12 @@ private constructor(
 
         fun build(): MastodonClient {
             return MastodonClient(
-                    instanceName,
-                    okHttpClientBuilder.addNetworkInterceptor(AuthorizationInterceptor(accessToken)).build(),
-                    gson
+                instanceName,
+                okHttpClientBuilder.addNetworkInterceptor(AuthorizationInterceptor(accessToken)).build(),
+                gson
             ).also {
                 it.debug = debug
             }
-        }
-    }
-
-    fun debugPrint(log: String) {
-        if (debug) {
-            println(log)
         }
     }
 
@@ -60,88 +194,15 @@ private constructor(
         override fun intercept(chain: Interceptor.Chain): Response {
             val originalRequest = chain.request()
             val compressedRequest = originalRequest.newBuilder()
-                    .headers(originalRequest.headers)
-                    .method(originalRequest.method, originalRequest.body)
-                    .apply {
-                        accessToken?.let {
-                            header("Authorization", String.format("Bearer %s", it));
-                        }
+                .headers(originalRequest.headers)
+                .method(originalRequest.method, originalRequest.body)
+                .apply {
+                    accessToken?.let {
+                        header("Authorization", String.format("Bearer %s", it))
                     }
-                    .build()
+                }
+                .build()
             return chain.proceed(compressedRequest)
-        }
-    }
-
-    open fun getSerializer() = gson
-
-    open fun getInstanceName() = instanceName
-
-    open fun get(path: String, parameter: Parameter? = null): Response {
-        try {
-            val url = "$baseUrl/$path"
-            debugPrint(url)
-            val urlWithParams = parameter?.let {
-                "$url?${it.build()}"
-            } ?: url
-            val call = client.newCall(
-                    Request.Builder()
-                            .url(urlWithParams)
-                            .get()
-                            .build())
-            return call.execute()
-        } catch (e: IOException) {
-            throw Mastodon4jRequestException(e)
-        }
-    }
-
-    open fun postUrl(url: String, body: RequestBody): Response {
-        try {
-            debugPrint(url)
-            val call = client.newCall(
-                    Request.Builder()
-                            .url(url)
-                            .post(body)
-                            .build())
-            return call.execute()
-        } catch (e: IllegalArgumentException) {
-            throw Mastodon4jRequestException(e)
-        } catch (e: IOException) {
-            throw Mastodon4jRequestException(e)
-        }
-    }
-
-    open fun post(path: String, body: RequestBody) =
-            postUrl("$baseUrl/$path", body)
-
-    open fun patch(path: String, body: RequestBody): Response {
-        try {
-            val url = "$baseUrl/$path"
-            debugPrint(url)
-            val call = client.newCall(
-                    Request.Builder()
-                            .url(url)
-                            .patch(body)
-                            .build()
-            )
-            return call.execute()
-        } catch (e: IOException) {
-            throw Mastodon4jRequestException(e)
-        }
-    }
-
-    open fun delete(path: String): Response {
-        try {
-            val url = "$baseUrl/$path"
-            debugPrint(url)
-            val call = client.newCall(
-                    Request.Builder()
-                            .url(url)
-                            .delete()
-                            .build()
-            )
-            return call.execute()
-        } catch (e: IOException) {
-            throw Mastodon4jRequestException(e)
         }
     }
 }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Accounts.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Accounts.kt
@@ -16,7 +16,7 @@ class Accounts(private val client: MastodonClient) {
     // GET /api/v1/accounts/:id
     fun getAccount(accountId: Long): MastodonRequest<Account> {
         return MastodonRequest(
-            { client.get("accounts/$accountId") },
+            { client.get("api/v1/accounts/$accountId") },
             { client.getSerializer().fromJson(it, Account::class.java) }
         )
     }
@@ -24,7 +24,7 @@ class Accounts(private val client: MastodonClient) {
     //  GET /api/v1/accounts/verify_credentials
     fun getVerifyCredentials(): MastodonRequest<Account> {
         return MastodonRequest(
-            { client.get("accounts/verify_credentials") },
+            { client.get("api/v1/accounts/verify_credentials") },
             { client.getSerializer().fromJson(it, Account::class.java) }
         )
     }
@@ -53,7 +53,7 @@ class Accounts(private val client: MastodonClient) {
         }
         return MastodonRequest(
             {
-                client.patch("accounts/update_credentials", parameters)
+                client.patch("api/v1/accounts/update_credentials", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Account::class.java)
@@ -67,7 +67,7 @@ class Accounts(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Account>>(
             {
                 client.get(
-                    "accounts/$accountId/followers",
+                    "api/v1/accounts/$accountId/followers",
                     range.toParameter()
                 )
             },
@@ -83,7 +83,7 @@ class Accounts(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Account>>(
             {
                 client.get(
-                    "accounts/$accountId/following",
+                    "api/v1/accounts/$accountId/following",
                     range.toParameter())
             },
             {
@@ -114,7 +114,7 @@ class Accounts(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Status>>(
             {
                 client.get(
-                    "accounts/$accountId/statuses",
+                    "api/v1/accounts/$accountId/statuses",
                     parameters
                 )
             },
@@ -128,7 +128,7 @@ class Accounts(private val client: MastodonClient) {
     fun postFollow(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("accounts/$accountId/follow")
+                client.post("api/v1/accounts/$accountId/follow")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -140,7 +140,7 @@ class Accounts(private val client: MastodonClient) {
     fun postUnFollow(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("accounts/$accountId/unfollow")
+                client.post("api/v1/accounts/$accountId/unfollow")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -152,7 +152,7 @@ class Accounts(private val client: MastodonClient) {
     fun postBlock(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("accounts/$accountId/block")
+                client.post("api/v1/accounts/$accountId/block")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -164,7 +164,7 @@ class Accounts(private val client: MastodonClient) {
     fun postUnblock(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("accounts/$accountId/unblock")
+                client.post("api/v1/accounts/$accountId/unblock")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -176,7 +176,7 @@ class Accounts(private val client: MastodonClient) {
     fun postMute(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("accounts/$accountId/mute")
+                client.post("api/v1/accounts/$accountId/mute")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -188,7 +188,7 @@ class Accounts(private val client: MastodonClient) {
     fun postUnmute(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("accounts/$accountId/unmute")
+                client.post("api/v1/accounts/$accountId/unmute")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -201,7 +201,7 @@ class Accounts(private val client: MastodonClient) {
         return MastodonRequest(
             {
                 client.get(
-                    "accounts/relationships",
+                    "api/v1/accounts/relationships",
                     Parameter().append("id", accountIds)
                 )
             },
@@ -221,7 +221,7 @@ class Accounts(private val client: MastodonClient) {
         return MastodonRequest(
             {
                 client.get(
-                    "accounts/search",
+                    "api/v1/accounts/search",
                     Parameter()
                         .append("q", query)
                         .append("limit", limit)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Accounts.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Accounts.kt
@@ -8,9 +8,6 @@ import com.sys1yagi.mastodon4j.api.Range
 import com.sys1yagi.mastodon4j.api.entity.Account
 import com.sys1yagi.mastodon4j.api.entity.Relationship
 import com.sys1yagi.mastodon4j.api.entity.Status
-import com.sys1yagi.mastodon4j.extension.emptyRequestBody
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#accounts
@@ -19,16 +16,16 @@ class Accounts(private val client: MastodonClient) {
     // GET /api/v1/accounts/:id
     fun getAccount(accountId: Long): MastodonRequest<Account> {
         return MastodonRequest(
-                { client.get("accounts/$accountId") },
-                { client.getSerializer().fromJson(it, Account::class.java) }
+            { client.get("accounts/$accountId") },
+            { client.getSerializer().fromJson(it, Account::class.java) }
         )
     }
 
     //  GET /api/v1/accounts/verify_credentials
     fun getVerifyCredentials(): MastodonRequest<Account> {
         return MastodonRequest(
-                { client.get("accounts/verify_credentials") },
-                { client.getSerializer().fromJson(it, Account::class.java) }
+            { client.get("accounts/verify_credentials") },
+            { client.getSerializer().fromJson(it, Account::class.java) }
         )
     }
 
@@ -53,17 +50,14 @@ class Accounts(private val client: MastodonClient) {
             header?.let {
                 append("header", it)
             }
-        }.build()
+        }
         return MastodonRequest(
-                {
-                    client.patch("accounts/update_credentials",
-                        parameters
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.patch("accounts/update_credentials", parameters)
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         )
     }
 
@@ -71,15 +65,15 @@ class Accounts(private val client: MastodonClient) {
     @JvmOverloads
     fun getFollowers(accountId: Long, range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
-                {
-                    client.get(
-                            "accounts/$accountId/followers",
-                            range.toParameter()
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.get(
+                    "accounts/$accountId/followers",
+                    range.toParameter()
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         ).toPageable()
     }
 
@@ -87,25 +81,25 @@ class Accounts(private val client: MastodonClient) {
     @JvmOverloads
     fun getFollowing(accountId: Long, range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
-                {
-                    client.get(
-                            "accounts/$accountId/following",
-                            range.toParameter())
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.get(
+                    "accounts/$accountId/following",
+                    range.toParameter())
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         ).toPageable()
     }
 
     //  GET /api/v1/accounts/:id/statuses
     @JvmOverloads
     fun getStatuses(
-            accountId: Long,
-            onlyMedia: Boolean = false,
-            excludeReplies: Boolean = false,
-            pinned: Boolean = false,
-            range: Range = Range()
+        accountId: Long,
+        onlyMedia: Boolean = false,
+        excludeReplies: Boolean = false,
+        pinned: Boolean = false,
+        range: Range = Range()
     ): MastodonRequest<Pageable<Status>> {
         val parameters = range.toParameter()
         if (onlyMedia) {
@@ -118,102 +112,102 @@ class Accounts(private val client: MastodonClient) {
             parameters.append("exclude_replies", true)
         }
         return MastodonRequest<Pageable<Status>>(
-                {
-                    client.get(
-                            "accounts/$accountId/statuses",
-                            parameters
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.get(
+                    "accounts/$accountId/statuses",
+                    parameters
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         ).toPageable()
     }
 
     //  POST /api/v1/accounts/:id/follow
     fun postFollow(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
-                {
-                    client.post("accounts/$accountId/follow", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.post("accounts/$accountId/follow")
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
     //  POST /api/v1/accounts/:id/unfollow
     fun postUnFollow(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
-                {
-                    client.post("accounts/$accountId/unfollow", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.post("accounts/$accountId/unfollow")
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
     //  POST /api/v1/accounts/:id/block
     fun postBlock(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
-                {
-                    client.post("accounts/$accountId/block", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.post("accounts/$accountId/block")
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
     //  POST /api/v1/accounts/:id/unblock
     fun postUnblock(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
-                {
-                    client.post("accounts/$accountId/unblock", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.post("accounts/$accountId/unblock")
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
     //  POST /api/v1/accounts/:id/mute
     fun postMute(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
-                {
-                    client.post("accounts/$accountId/mute", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.post("accounts/$accountId/mute")
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
     //  POST /api/v1/accounts/:id/unmute
     fun postUnmute(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
-                {
-                    client.post("accounts/$accountId/unmute", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.post("accounts/$accountId/unmute")
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
     //  GET /api/v1/accounts/relationships
     fun getRelationships(accountIds: List<Long>): MastodonRequest<List<Relationship>> {
         return MastodonRequest(
-                {
-                    client.get(
-                            "accounts/relationships",
-                            Parameter().append("id", accountIds)
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Relationship::class.java)
-                }
+            {
+                client.get(
+                    "accounts/relationships",
+                    Parameter().append("id", accountIds)
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
         )
     }
 
@@ -225,17 +219,17 @@ class Accounts(private val client: MastodonClient) {
     @JvmOverloads
     fun getAccountSearch(query: String, limit: Int = 40): MastodonRequest<List<Account>> {
         return MastodonRequest(
-                {
-                    client.get(
-                            "accounts/search",
-                            Parameter()
-                                    .append("q", query)
-                                    .append("limit", limit)
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.get(
+                    "accounts/search",
+                    Parameter()
+                        .append("q", query)
+                        .append("limit", limit)
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         )
     }
 }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
@@ -31,7 +31,7 @@ class Apps(private val client: MastodonClient) {
         scope.validate()
         return MastodonRequest(
             {
-                client.post("apps",
+                client.post("api/v1/apps",
                     Parameter().apply {
                         append("client_name", clientName)
                         append("scopes", scope.toString())
@@ -82,8 +82,6 @@ class Apps(private val client: MastodonClient) {
         code: String,
         grantType: String = "authorization_code"
     ): MastodonRequest<AccessToken> {
-        val url = "https://${client.getInstanceName()}/oauth/token"
-
         val parameters = Parameter().apply {
             append("client_id", clientId)
             append("client_secret", clientSecret)
@@ -93,7 +91,7 @@ class Apps(private val client: MastodonClient) {
         }
         return MastodonRequest(
             {
-                client.postUrl(url, parameters)
+                client.post("oauth/token", parameters)
             },
             {
                 client.getSerializer().fromJson(it, AccessToken::class.java)
@@ -119,7 +117,6 @@ class Apps(private val client: MastodonClient) {
         userName: String,
         password: String
     ): MastodonRequest<AccessToken> {
-        val url = "https://${client.getInstanceName()}/oauth/token"
         val parameters = Parameter().apply {
             append("client_id", clientId)
             append("client_secret", clientSecret)
@@ -131,7 +128,7 @@ class Apps(private val client: MastodonClient) {
 
         return MastodonRequest(
             {
-                client.postUrl(url, parameters)
+                client.post("oauth/token", parameters)
             },
             {
                 client.getSerializer().fromJson(it, AccessToken::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
@@ -6,8 +6,6 @@ import com.sys1yagi.mastodon4j.Parameter
 import com.sys1yagi.mastodon4j.api.Scope
 import com.sys1yagi.mastodon4j.api.entity.auth.AccessToken
 import com.sys1yagi.mastodon4j.api.entity.auth.AppRegistration
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * Register client applications that can be used to obtain OAuth tokens.
@@ -34,16 +32,14 @@ class Apps(private val client: MastodonClient) {
         return MastodonRequest(
             {
                 client.post("apps",
-                    arrayListOf(
-                        "client_name=$clientName",
-                        "scopes=$scope",
-                        "redirect_uris=$redirectUris"
-                    ).apply {
+                    Parameter().apply {
+                        append("client_name", clientName)
+                        append("scopes", scope.toString())
+                        append("redirect_uris", redirectUris)
                         website?.let {
-                            add("website=${it}")
+                            append("website", it)
                         }
-                    }.joinToString(separator = "&")
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+                    }
                 )
             },
             {
@@ -87,19 +83,17 @@ class Apps(private val client: MastodonClient) {
         grantType: String = "authorization_code"
     ): MastodonRequest<AccessToken> {
         val url = "https://${client.getInstanceName()}/oauth/token"
-        val parameters = listOf(
-            "client_id=$clientId",
-            "client_secret=$clientSecret",
-            "redirect_uri=$redirectUri",
-            "code=$code",
-            "grant_type=$grantType"
-        ).joinToString(separator = "&")
+
+        val parameters = Parameter().apply {
+            append("client_id", clientId)
+            append("client_secret", clientSecret)
+            append("redirect_uri", redirectUri)
+            append("code", code)
+            append("grant_type", grantType)
+        }
         return MastodonRequest(
             {
-                client.postUrl(url,
-                    parameters
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                )
+                client.postUrl(url, parameters)
             },
             {
                 client.getSerializer().fromJson(it, AccessToken::class.java)
@@ -133,14 +127,11 @@ class Apps(private val client: MastodonClient) {
             append("username", userName)
             append("password", password)
             append("grant_type", "password")
-        }.build()
+        }
 
         return MastodonRequest(
             {
-                client.postUrl(url,
-                    parameters
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                )
+                client.postUrl(url, parameters)
             },
             {
                 client.getSerializer().fromJson(it, AccessToken::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Apps.kt
@@ -59,14 +59,14 @@ class Apps(private val client: MastodonClient) {
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#authorize">Mastodon oauth API methods #authorize</a>
      */
     fun getOAuthUrl(clientId: String, scope: Scope, redirectUri: String = "urn:ietf:wg:oauth:2.0:oob"): String {
-        val endpoint = "/oauth/authorize"
-        val parameters = listOf(
-            "client_id=$clientId",
-            "redirect_uri=$redirectUri",
-            "response_type=code",
-            "scope=$scope"
-        ).joinToString(separator = "&")
-        return "https://${client.getInstanceName()}$endpoint?$parameters"
+        val endpoint = "oauth/authorize"
+        val parameters = Parameter()
+            .append("client_id", clientId)
+            .append("redirect_uri", redirectUri)
+            .append("response_type", "code")
+            .append("scope", scope.toString())
+
+        return MastodonClient.fullUrl(client.getInstanceName(), endpoint, parameters).toString()
     }
 
     /**

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Blocks.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Blocks.kt
@@ -16,7 +16,7 @@ class Blocks(private val client: MastodonClient) {
     fun getBlocks(range: Range = Range()):MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
                 {
-                    client.get("blocks", range.toParameter())
+                    client.get("api/v1/blocks", range.toParameter())
                 },
                 {
                     client.getSerializer().fromJson(it, Account::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Favourites.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Favourites.kt
@@ -16,7 +16,7 @@ class Favourites(private val client: MastodonClient) {
     fun getFavourites(range: Range = Range()): MastodonRequest<Pageable<Status>> {
         return MastodonRequest<Pageable<Status>>(
                 {
-                    client.get("favourites", range.toParameter())
+                    client.get("api/v1/favourites", range.toParameter())
                 },
                 {
                     client.getSerializer().fromJson(it, Status::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/FollowRequests.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/FollowRequests.kt
@@ -15,7 +15,7 @@ class FollowRequests(private val client: MastodonClient) {
     @JvmOverloads
     fun getFollowRequests(range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
-            { client.get("follow_requests", range.toParameter()) },
+            { client.get("api/v1/follow_requests", range.toParameter()) },
             {
                 client.getSerializer().fromJson(it, Account::class.java)
             }
@@ -25,7 +25,7 @@ class FollowRequests(private val client: MastodonClient) {
     //  POST /api/v1/follow_requests/:id/authorize
     @Throws(Mastodon4jRequestException::class)
     fun postAuthorize(accountId: Long) {
-        val response = client.post("follow_requests/$accountId/authorize")
+        val response = client.post("api/v1/follow_requests/$accountId/authorize")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }
@@ -34,7 +34,7 @@ class FollowRequests(private val client: MastodonClient) {
     //  POST /api/v1/follow_requests/:id/reject
     @Throws(Mastodon4jRequestException::class)
     fun postReject(accountId: Long) {
-        val response = client.post("follow_requests/$accountId/reject")
+        val response = client.post("api/v1/follow_requests/$accountId/reject")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/FollowRequests.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/FollowRequests.kt
@@ -6,7 +6,6 @@ import com.sys1yagi.mastodon4j.api.Pageable
 import com.sys1yagi.mastodon4j.api.Range
 import com.sys1yagi.mastodon4j.api.entity.Account
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
-import com.sys1yagi.mastodon4j.extension.emptyRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#follow-requests
@@ -16,17 +15,17 @@ class FollowRequests(private val client: MastodonClient) {
     @JvmOverloads
     fun getFollowRequests(range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
-                { client.get("follow_requests", range.toParameter()) },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            { client.get("follow_requests", range.toParameter()) },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         ).toPageable()
     }
 
     //  POST /api/v1/follow_requests/:id/authorize
     @Throws(Mastodon4jRequestException::class)
     fun postAuthorize(accountId: Long) {
-        val response = client.post("follow_requests/$accountId/authorize", emptyRequestBody())
+        val response = client.post("follow_requests/$accountId/authorize")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }
@@ -35,7 +34,7 @@ class FollowRequests(private val client: MastodonClient) {
     //  POST /api/v1/follow_requests/:id/reject
     @Throws(Mastodon4jRequestException::class)
     fun postReject(accountId: Long) {
-        val response = client.post("follow_requests/$accountId/reject", emptyRequestBody())
+        val response = client.post("follow_requests/$accountId/reject")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Follows.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Follows.kt
@@ -19,7 +19,7 @@ class Follows(private val client: MastodonClient) {
         }
         return MastodonRequest<Account>(
             {
-                client.post("follows", parameters)
+                client.post("api/v1/follows", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Account::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Follows.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Follows.kt
@@ -4,8 +4,6 @@ import com.sys1yagi.mastodon4j.MastodonClient
 import com.sys1yagi.mastodon4j.MastodonRequest
 import com.sys1yagi.mastodon4j.Parameter
 import com.sys1yagi.mastodon4j.api.entity.Account
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#follows
@@ -16,19 +14,16 @@ class Follows(private val client: MastodonClient) {
      * @param uri: username@domain of the person you want to follow
      */
     fun postRemoteFollow(uri: String): MastodonRequest<Account> {
-        val parameters = Parameter()
-                .append("uri", uri)
-                .build()
+        val parameters = Parameter().apply {
+            append("uri", uri)
+        }
         return MastodonRequest<Account>(
-                {
-                    client.post("follows",
-                        parameters
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.post("follows", parameters)
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         )
     }
 }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/MastodonLists.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/MastodonLists.kt
@@ -15,7 +15,7 @@ class MastodonLists(private val client: MastodonClient) {
         return MastodonRequest<Pageable<MastodonList>>(
                 {
                     client.get(
-                            "lists"
+                            "api/v1/lists"
                     )
                 },
                 {
@@ -30,7 +30,7 @@ class MastodonLists(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Status>>(
                 {
                     client.get(
-                            "timelines/list/$listID",
+                            "api/v1/timelines/list/$listID",
                             range.toParameter()
                     )
                 },

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Media.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Media.kt
@@ -17,7 +17,7 @@ class Media(private val client: MastodonClient) {
                 .build()
         return MastodonRequest<Attachment>(
                 {
-                    client.post("media", requestBody)
+                    client.postRequestBody("media", requestBody)
                 },
                 {
                     client.getSerializer().fromJson(it, Attachment::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Mutes.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Mutes.kt
@@ -15,7 +15,7 @@ class Mutes(private val client: MastodonClient) {
     fun getMutes(range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
                 {
-                    client.get("mutes", range.toParameter())
+                    client.get("api/v1/mutes", range.toParameter())
                 },
                 {
                     client.getSerializer().fromJson(it, Account::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Notifications.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Notifications.kt
@@ -6,7 +6,6 @@ import com.sys1yagi.mastodon4j.api.Pageable
 import com.sys1yagi.mastodon4j.api.Range
 import com.sys1yagi.mastodon4j.api.entity.Notification
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
-import com.sys1yagi.mastodon4j.extension.emptyRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#notifications
@@ -20,36 +19,34 @@ class Notifications(private val client: MastodonClient) {
             parameter.append("exclude_types", excludeTypes.map { it.value })
         }
         return MastodonRequest<Pageable<Notification>>(
-                {
-                    client.get(
-                            "notifications",
-                            parameter
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Notification::class.java)
-                }
+            {
+                client.get(
+                    "notifications",
+                    parameter
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Notification::class.java)
+            }
         ).toPageable()
     }
 
     // GET /api/v1/notifications/:id
     fun getNotification(id: Long): MastodonRequest<Notification> {
         return MastodonRequest<Notification>(
-                {
-                    client.get("notifications/$id")
-                },
-                {
-                    client.getSerializer().fromJson(it, Notification::class.java)
-                }
+            {
+                client.get("notifications/$id")
+            },
+            {
+                client.getSerializer().fromJson(it, Notification::class.java)
+            }
         )
     }
 
     //  POST /api/v1/notifications/clear
     @Throws(Mastodon4jRequestException::class)
     fun clearNotifications() {
-        val response = client.post("notifications/clear",
-                emptyRequestBody()
-        )
+        val response = client.post("notifications/clear")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Notifications.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Notifications.kt
@@ -21,7 +21,7 @@ class Notifications(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Notification>>(
             {
                 client.get(
-                    "notifications",
+                    "api/v1/notifications",
                     parameter
                 )
             },
@@ -35,7 +35,7 @@ class Notifications(private val client: MastodonClient) {
     fun getNotification(id: Long): MastodonRequest<Notification> {
         return MastodonRequest<Notification>(
             {
-                client.get("notifications/$id")
+                client.get("api/v1/notifications/$id")
             },
             {
                 client.getSerializer().fromJson(it, Notification::class.java)
@@ -46,7 +46,7 @@ class Notifications(private val client: MastodonClient) {
     //  POST /api/v1/notifications/clear
     @Throws(Mastodon4jRequestException::class)
     fun clearNotifications() {
-        val response = client.post("notifications/clear")
+        val response = client.post("api/v1/notifications/clear")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Public.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Public.kt
@@ -19,7 +19,7 @@ class Public(private val client: MastodonClient) {
     fun getInstance(): MastodonRequest<Instance> {
         return MastodonRequest(
                 {
-                    client.get("instance")
+                    client.get("api/v1/instance")
                 },
                 { json ->
                     client.getSerializer().fromJson(json, Instance::class.java)
@@ -40,7 +40,7 @@ class Public(private val client: MastodonClient) {
         return MastodonRequest<Results>(
                 {
                     client.get(
-                            "search",
+                            "api/v1/search",
                             Parameter().apply {
                                 append("q", query)
                                 if (resolve) {
@@ -67,7 +67,7 @@ class Public(private val client: MastodonClient) {
         }
         return MastodonRequest<Pageable<Status>>(
                 {
-                    client.get("timelines/public", parameter)
+                    client.get("api/v1/timelines/public", parameter)
                 },
                 {
                     client.getSerializer().fromJson(it, Status::class.java)
@@ -93,7 +93,7 @@ class Public(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Status>>(
                 {
                     client.get(
-                            "timelines/tag/$tag",
+                            "api/v1/timelines/tag/$tag",
                             parameter
                     )
                 },

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Reports.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Reports.kt
@@ -7,8 +7,6 @@ import com.sys1yagi.mastodon4j.api.Pageable
 import com.sys1yagi.mastodon4j.api.Range
 import com.sys1yagi.mastodon4j.api.entity.Report
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#reports
@@ -19,15 +17,15 @@ class Reports(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun getReports(range: Range = Range()): MastodonRequest<Pageable<Report>> {
         return MastodonRequest<Pageable<Report>>(
-                {
-                    client.get(
-                            "reports",
-                            range.toParameter()
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Report::class.java)
-                }
+            {
+                client.get(
+                    "reports",
+                    range.toParameter()
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Report::class.java)
+            }
         ).toPageable()
     }
 
@@ -43,17 +41,14 @@ class Reports(private val client: MastodonClient) {
             append("account_id", accountId)
             append("status_ids", statusId)
             append("comment", comment)
-        }.build()
+        }
         return MastodonRequest<Report>(
-                {
-                    client.post("reports",
-                        parameters
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Report::class.java)
-                }
+            {
+                client.post("reports", parameters)
+            },
+            {
+                client.getSerializer().fromJson(it, Report::class.java)
+            }
         )
     }
 }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Reports.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Reports.kt
@@ -19,7 +19,7 @@ class Reports(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Report>>(
             {
                 client.get(
-                    "reports",
+                    "api/v1/reports",
                     range.toParameter()
                 )
             },
@@ -44,7 +44,7 @@ class Reports(private val client: MastodonClient) {
         }
         return MastodonRequest<Report>(
             {
-                client.post("reports", parameters)
+                client.post("api/v1/reports", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Report::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Statuses.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Statuses.kt
@@ -10,9 +10,6 @@ import com.sys1yagi.mastodon4j.api.entity.Card
 import com.sys1yagi.mastodon4j.api.entity.Context
 import com.sys1yagi.mastodon4j.api.entity.Status
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
-import com.sys1yagi.mastodon4j.extension.emptyRequestBody
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#statuses
@@ -23,12 +20,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun getStatus(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
-                {
-                    client.get("statuses/$statusId")
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.get("statuses/$statusId")
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         )
     }
 
@@ -36,12 +33,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun getContext(statusId: Long): MastodonRequest<Context> {
         return MastodonRequest<Context>(
-                {
-                    client.get("statuses/$statusId/context")
-                },
-                {
-                    client.getSerializer().fromJson(it, Context::class.java)
-                }
+            {
+                client.get("statuses/$statusId/context")
+            },
+            {
+                client.getSerializer().fromJson(it, Context::class.java)
+            }
         )
     }
 
@@ -49,12 +46,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun getCard(statusId: Long): MastodonRequest<Card> {
         return MastodonRequest<Card>(
-                {
-                    client.get("statuses/$statusId/card")
-                },
-                {
-                    client.getSerializer().fromJson(it, Card::class.java)
-                }
+            {
+                client.get("statuses/$statusId/card")
+            },
+            {
+                client.getSerializer().fromJson(it, Card::class.java)
+            }
         )
     }
 
@@ -63,15 +60,15 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun getRebloggedBy(statusId: Long, range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
-                {
-                    client.get(
-                            "statuses/$statusId/reblogged_by",
-                            range.toParameter()
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.get(
+                    "statuses/$statusId/reblogged_by",
+                    range.toParameter()
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         ).toPageable()
     }
 
@@ -80,15 +77,15 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun getFavouritedBy(statusId: Long, range: Range = Range()): MastodonRequest<Pageable<Account>> {
         return MastodonRequest<Pageable<Account>>(
-                {
-                    client.get(
-                            "statuses/$statusId/favourited_by",
-                            range.toParameter()
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Account::class.java)
-                }
+            {
+                client.get(
+                    "statuses/$statusId/favourited_by",
+                    range.toParameter()
+                )
+            },
+            {
+                client.getSerializer().fromJson(it, Account::class.java)
+            }
         ).toPageable()
     }
 
@@ -104,12 +101,12 @@ class Statuses(private val client: MastodonClient) {
     @JvmOverloads
     @Throws(Mastodon4jRequestException::class)
     fun postStatus(
-            status: String,
-            inReplyToId: Long?,
-            mediaIds: List<Long>?,
-            sensitive: Boolean,
-            spoilerText: String?,
-            visibility: Status.Visibility = Status.Visibility.Public
+        status: String,
+        inReplyToId: Long?,
+        mediaIds: List<Long>?,
+        sensitive: Boolean,
+        spoilerText: String?,
+        visibility: Status.Visibility = Status.Visibility.Public
     ): MastodonRequest<Status> {
         val parameters = Parameter().apply {
             append("status", status)
@@ -124,18 +121,15 @@ class Statuses(private val client: MastodonClient) {
                 append("spoiler_text", it)
             }
             append("visibility", visibility.value)
-        }.build()
+        }
 
         return MastodonRequest<Status>(
-                {
-                    client.post("statuses",
-                        parameters
-                            .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                    )
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.post("statuses", parameters)
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         )
     }
 
@@ -152,12 +146,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun postReblog(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
-                {
-                    client.post("statuses/$statusId/reblog", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.post("statuses/$statusId/reblog")
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         )
     }
 
@@ -165,12 +159,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun postUnreblog(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
-                {
-                    client.post("statuses/$statusId/unreblog", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.post("statuses/$statusId/unreblog")
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         )
     }
 
@@ -178,12 +172,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun postFavourite(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
-                {
-                    client.post("statuses/$statusId/favourite", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.post("statuses/$statusId/favourite")
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         )
     }
 
@@ -191,12 +185,12 @@ class Statuses(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun postUnfavourite(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
-                {
-                    client.post("statuses/$statusId/unfavourite", emptyRequestBody())
-                },
-                {
-                    client.getSerializer().fromJson(it, Status::class.java)
-                }
+            {
+                client.post("statuses/$statusId/unfavourite")
+            },
+            {
+                client.getSerializer().fromJson(it, Status::class.java)
+            }
         )
     }
 }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Statuses.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Statuses.kt
@@ -21,7 +21,7 @@ class Statuses(private val client: MastodonClient) {
     fun getStatus(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.get("statuses/$statusId")
+                client.get("api/v1/statuses/$statusId")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -34,7 +34,7 @@ class Statuses(private val client: MastodonClient) {
     fun getContext(statusId: Long): MastodonRequest<Context> {
         return MastodonRequest<Context>(
             {
-                client.get("statuses/$statusId/context")
+                client.get("api/v1/statuses/$statusId/context")
             },
             {
                 client.getSerializer().fromJson(it, Context::class.java)
@@ -47,7 +47,7 @@ class Statuses(private val client: MastodonClient) {
     fun getCard(statusId: Long): MastodonRequest<Card> {
         return MastodonRequest<Card>(
             {
-                client.get("statuses/$statusId/card")
+                client.get("api/v1/statuses/$statusId/card")
             },
             {
                 client.getSerializer().fromJson(it, Card::class.java)
@@ -62,7 +62,7 @@ class Statuses(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Account>>(
             {
                 client.get(
-                    "statuses/$statusId/reblogged_by",
+                    "api/v1/statuses/$statusId/reblogged_by",
                     range.toParameter()
                 )
             },
@@ -79,7 +79,7 @@ class Statuses(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Account>>(
             {
                 client.get(
-                    "statuses/$statusId/favourited_by",
+                    "api/v1/statuses/$statusId/favourited_by",
                     range.toParameter()
                 )
             },
@@ -125,7 +125,7 @@ class Statuses(private val client: MastodonClient) {
 
         return MastodonRequest<Status>(
             {
-                client.post("statuses", parameters)
+                client.post("api/v1/statuses", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -136,7 +136,7 @@ class Statuses(private val client: MastodonClient) {
     //  DELETE /api/v1/statuses/:id
     @Throws(Mastodon4jRequestException::class)
     fun deleteStatus(statusId: Long) {
-        val response = client.delete("statuses/$statusId")
+        val response = client.delete("api/v1/statuses/$statusId")
         if (!response.isSuccessful) {
             throw Mastodon4jRequestException(response)
         }
@@ -147,7 +147,7 @@ class Statuses(private val client: MastodonClient) {
     fun postReblog(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("statuses/$statusId/reblog")
+                client.post("api/v1/statuses/$statusId/reblog")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -160,7 +160,7 @@ class Statuses(private val client: MastodonClient) {
     fun postUnreblog(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("statuses/$statusId/unreblog")
+                client.post("api/v1/statuses/$statusId/unreblog")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -173,7 +173,7 @@ class Statuses(private val client: MastodonClient) {
     fun postFavourite(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("statuses/$statusId/favourite")
+                client.post("api/v1/statuses/$statusId/favourite")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -186,7 +186,7 @@ class Statuses(private val client: MastodonClient) {
     fun postUnfavourite(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("statuses/$statusId/unfavourite")
+                client.post("api/v1/statuses/$statusId/unfavourite")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Streaming.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Streaming.kt
@@ -12,7 +12,7 @@ import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException
 class Streaming(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun federatedPublic(handler: Handler): Shutdownable {
-        val response = client.get("streaming/public")
+        val response = client.get("api/v1/streaming/public")
         if (response.isSuccessful) {
             val reader = response.body?.byteStream()?.bufferedReader()
             val dispatcher = Dispatcher()
@@ -56,7 +56,7 @@ class Streaming(private val client: MastodonClient) {
 
     @Throws(Mastodon4jRequestException::class)
     fun localPublic(handler: Handler): Shutdownable {
-        val response = client.get("streaming/public/local")
+        val response = client.get("api/v1/streaming/public/local")
         if (response.isSuccessful) {
             val reader = response.body?.byteStream()?.bufferedReader()
             val dispatcher = Dispatcher()
@@ -101,7 +101,7 @@ class Streaming(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun federatedHashtag(tag: String, handler: Handler): Shutdownable {
         val response = client.get(
-                "streaming/hashtag",
+                "api/v1/streaming/hashtag",
                 Parameter().append("tag", tag)
         )
         if (response.isSuccessful) {
@@ -148,7 +148,7 @@ class Streaming(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun localHashtag(tag: String, handler: Handler): Shutdownable {
         val response = client.get(
-                "streaming/hashtag/local",
+                "api/v1/streaming/hashtag/local",
                 Parameter().append("tag", tag)
         )
         if (response.isSuccessful) {
@@ -195,7 +195,7 @@ class Streaming(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun user(handler: Handler): Shutdownable {
         val response = client.get(
-                "streaming/user"
+                "api/v1/streaming/user"
         )
         if (response.isSuccessful) {
             val reader = response.body?.byteStream()?.bufferedReader()
@@ -256,7 +256,7 @@ class Streaming(private val client: MastodonClient) {
     @Throws(Mastodon4jRequestException::class)
     fun userList(handler: Handler, listID: String): Shutdownable {
         val response = client.get(
-                "streaming/list",
+                "api/v1/streaming/list",
                 Parameter().apply {
                     append("list", listID)
                 }

--- a/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Timelines.kt
+++ b/mastodon4j/src/main/kotlin/com/sys1yagi/mastodon4j/api/method/Timelines.kt
@@ -18,7 +18,7 @@ class Timelines(private val client: MastodonClient) {
         return MastodonRequest<Pageable<Status>>(
                 {
                     client.get(
-                            "timelines/home",
+                            "api/v1/timelines/home",
                             range.toParameter()
                     )
                 },

--- a/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/api/method/AppsTest.kt
+++ b/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/api/method/AppsTest.kt
@@ -47,7 +47,7 @@ class AppsTest {
 
         val url = Apps(client).getOAuthUrl("client_id", Scope(Scope.Name.ALL))
         url shouldBeEqualTo "https://mastodon.cloud/oauth/authorize?client_id=client_id" +
-                "&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=read write follow"
+                "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write+follow"
     }
 
     @Test

--- a/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/testtool/MockClient.kt
+++ b/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/testtool/MockClient.kt
@@ -2,6 +2,7 @@ package com.sys1yagi.mastodon4j.testtool
 
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.MastodonClient
+import com.sys1yagi.mastodon4j.Parameter
 import io.mockk.every
 import io.mockk.mockk
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -18,32 +19,33 @@ object MockClient {
     fun mock(jsonName: String, maxId: Long? = null, sinceId: Long? = null): MastodonClient {
         val clientMock: MastodonClient = mockk()
         val response: Response = Response.Builder()
-                .code(200)
-                .message("OK")
-                .request(Request.Builder().url("https://test.com/").build())
-                .protocol(Protocol.HTTP_1_1)
-                .body(
-                    AssetsUtil.readFromAssets(jsonName)
-                        .toResponseBody("application/json; charset=utf-8".toMediaTypeOrNull())
-                )
-                .apply {
-                    val linkHeader = arrayListOf<String>().apply {
-                        maxId?.let {
-                            add("""<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&max_id=$it>; rel="next"""")
-                        }
-                        sinceId?.let {
-                            add("""<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&since_id=$it>; rel="prev"""")
-                        }
-                    }.joinToString(separator = ",")
-                    if (linkHeader.isNotEmpty()) {
-                        header("link", linkHeader)
+            .code(200)
+            .message("OK")
+            .request(Request.Builder().url("https://test.com/").build())
+            .protocol(Protocol.HTTP_1_1)
+            .body(
+                AssetsUtil.readFromAssets(jsonName)
+                    .toResponseBody("application/json; charset=utf-8".toMediaTypeOrNull())
+            )
+            .apply {
+                val linkHeader = arrayListOf<String>().apply {
+                    maxId?.let {
+                        add("""<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&max_id=$it>; rel="next"""")
                     }
+                    sinceId?.let {
+                        add("""<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&since_id=$it>; rel="prev"""")
+                    }
+                }.joinToString(separator = ",")
+                if (linkHeader.isNotEmpty()) {
+                    header("link", linkHeader)
                 }
-                .build()
+            }
+            .build()
 
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
-        every { clientMock.post(ofType<String>(), any()) } returns response
+        every { clientMock.post(ofType<String>(), Parameter()) } returns response
+        every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.postUrl(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()
@@ -55,22 +57,23 @@ object MockClient {
         val source: BufferedSource = mockk()
         every { source.readString(any()) } throws SocketTimeoutException()
         val response: Response = Response.Builder()
-                .code(200)
-                .message("OK")
-                .request(Request.Builder().url("https://test.com/").build())
-                .protocol(Protocol.HTTP_1_1)
-                .body(
-                    source
-                        .asResponseBody(
-                            "application/json; charset=utf-8".toMediaTypeOrNull(),
-                            1024
-                        )
-                )
-                .build()
+            .code(200)
+            .message("OK")
+            .request(Request.Builder().url("https://test.com/").build())
+            .protocol(Protocol.HTTP_1_1)
+            .body(
+                source
+                    .asResponseBody(
+                        "application/json; charset=utf-8".toMediaTypeOrNull(),
+                        1024
+                    )
+            )
+            .build()
 
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
-        every { clientMock.post(ofType<String>(), any()) } returns response
+        every { clientMock.post(ofType<String>(), Parameter()) } returns response
+        every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.postUrl(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()

--- a/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/testtool/MockClient.kt
+++ b/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/testtool/MockClient.kt
@@ -2,7 +2,6 @@ package com.sys1yagi.mastodon4j.testtool
 
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.MastodonClient
-import com.sys1yagi.mastodon4j.Parameter
 import io.mockk.every
 import io.mockk.mockk
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -44,7 +43,7 @@ object MockClient {
 
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
-        every { clientMock.post(ofType<String>(), Parameter()) } returns response
+        every { clientMock.post(ofType<String>(), any()) } returns response
         every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.postUrl(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
@@ -72,7 +71,7 @@ object MockClient {
 
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
-        every { clientMock.post(ofType<String>(), Parameter()) } returns response
+        every { clientMock.post(ofType<String>(), any()) } returns response
         every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.postUrl(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response

--- a/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/testtool/MockClient.kt
+++ b/mastodon4j/src/test/kotlin/com/sys1yagi/mastodon4j/testtool/MockClient.kt
@@ -45,7 +45,6 @@ object MockClient {
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
         every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
-        every { clientMock.postUrl(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()
         return clientMock
@@ -73,7 +72,6 @@ object MockClient {
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
         every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
-        every { clientMock.postUrl(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()
         return clientMock

--- a/sample-kotlin/src/main/kotlin/com/sys1yagi/mastodon4j/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/com/sys1yagi/mastodon4j/sample/Authenticator.kt
@@ -6,7 +6,6 @@ import com.sys1yagi.mastodon4j.api.Scope
 import com.sys1yagi.mastodon4j.api.entity.auth.AccessToken
 import com.sys1yagi.mastodon4j.api.entity.auth.AppRegistration
 import com.sys1yagi.mastodon4j.api.method.Apps
-import okhttp3.OkHttpClient
 import java.io.File
 import java.util.Properties
 
@@ -53,7 +52,7 @@ object Authenticator {
         } else {
             println("access token found...")
         }
-        return MastodonClient.Builder(instanceName, OkHttpClient.Builder(), Gson())
+        return MastodonClient.Builder(instanceName, Gson())
                 .accessToken(properties[ACCESS_TOKEN].toString())
                 .apply {
                     if (useStreaming) {
@@ -69,13 +68,13 @@ object Authenticator {
                                email: String,
                                password: String
     ): AccessToken {
-        val client = MastodonClient.Builder(instanceName, OkHttpClient.Builder(), Gson()).build()
+        val client = MastodonClient.Builder(instanceName, Gson()).build()
         val apps = Apps(client)
         return apps.postUserNameAndPassword(clientId, clientSecret, Scope(), email, password).execute()
     }
 
     private fun appRegistration(instanceName: String): AppRegistration {
-        val client = MastodonClient.Builder(instanceName, OkHttpClient.Builder(), Gson()).build()
+        val client = MastodonClient.Builder(instanceName, Gson()).build()
         val apps = Apps(client)
         return apps.createApp(
                 "kotlindon",

--- a/sample/src/main/java/com/sys1yagi/mastodon4j/sample/Authenticator.java
+++ b/sample/src/main/java/com/sys1yagi/mastodon4j/sample/Authenticator.java
@@ -7,7 +7,6 @@ import com.sys1yagi.mastodon4j.api.entity.auth.AccessToken;
 import com.sys1yagi.mastodon4j.api.entity.auth.AppRegistration;
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException;
 import com.sys1yagi.mastodon4j.api.method.Apps;
-import okhttp3.OkHttpClient;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -52,7 +51,7 @@ final class Authenticator {
         } else {
             System.out.println("access token found...");
         }
-        MastodonClient.Builder builder = new MastodonClient.Builder(instanceName, new OkHttpClient.Builder(), new Gson())
+        MastodonClient.Builder builder = new MastodonClient.Builder(instanceName, new Gson())
             .accessToken(properties.get(ACCESS_TOKEN).toString());
         if (useStreaming) {
             builder.useStreamingApi();
@@ -61,13 +60,13 @@ final class Authenticator {
     }
 
     private static AccessToken getAccessToken(String instanceName, String clientId, String clientSecret, String email, String password) throws Mastodon4jRequestException {
-        MastodonClient client = new MastodonClient.Builder(instanceName, new OkHttpClient.Builder(), new Gson()).build();
+        MastodonClient client = new MastodonClient.Builder(instanceName, new Gson()).build();
         Apps apps = new Apps(client);
         return apps.postUserNameAndPassword(clientId, clientSecret, new Scope(), email, password).execute();
     }
 
     private static AppRegistration appRegistration(String instanceName) throws Mastodon4jRequestException {
-        MastodonClient client = new MastodonClient.Builder(instanceName, new OkHttpClient.Builder(), new Gson()).build();
+        MastodonClient client = new MastodonClient.Builder(instanceName, new Gson()).build();
         Apps apps = new Apps(client);
         return apps.createApp("kotlindon", "urn:ietf:wg:oauth:2.0:oob", new Scope(), null).execute();
     }

--- a/sample/src/main/java/com/sys1yagi/mastodon4j/sample/GetAppRegistration.java
+++ b/sample/src/main/java/com/sys1yagi/mastodon4j/sample/GetAppRegistration.java
@@ -7,11 +7,10 @@ import com.sys1yagi.mastodon4j.api.Scope;
 import com.sys1yagi.mastodon4j.api.entity.auth.AppRegistration;
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException;
 import com.sys1yagi.mastodon4j.api.method.Apps;
-import okhttp3.OkHttpClient;
 
 public class GetAppRegistration {
     public static void main(String[] args) {
-        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson()).build();
+        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new Gson()).build();
         Apps apps = new Apps(client);
         try {
             AppRegistration registration = apps.createApp(

--- a/sample/src/main/java/com/sys1yagi/mastodon4j/sample/GetPublicTimelines.java
+++ b/sample/src/main/java/com/sys1yagi/mastodon4j/sample/GetPublicTimelines.java
@@ -7,11 +7,10 @@ import com.sys1yagi.mastodon4j.api.Range;
 import com.sys1yagi.mastodon4j.api.entity.Status;
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException;
 import com.sys1yagi.mastodon4j.api.method.Public;
-import okhttp3.OkHttpClient;
 
 public class GetPublicTimelines {
     public static void main(String[] args) {
-        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson()).build();
+        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new Gson()).build();
         Public publicMethod = new Public(client);
 
         try {

--- a/sample/src/main/java/com/sys1yagi/mastodon4j/sample/GetTagTimelines.java
+++ b/sample/src/main/java/com/sys1yagi/mastodon4j/sample/GetTagTimelines.java
@@ -7,14 +7,10 @@ import com.sys1yagi.mastodon4j.api.Range;
 import com.sys1yagi.mastodon4j.api.entity.Status;
 import com.sys1yagi.mastodon4j.api.exception.Mastodon4jRequestException;
 import com.sys1yagi.mastodon4j.api.method.Public;
-import com.sys1yagi.mastodon4j.api.method.Timelines;
-import okhttp3.OkHttpClient;
-
-import java.util.List;
 
 public class GetTagTimelines {
     public static void main(String[] args) {
-        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson()).build();
+        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new Gson()).build();
         Public publicMethod = new Public(client);
 
         try {

--- a/sample/src/main/java/com/sys1yagi/mastodon4j/sample/StreamPublicTimeline.java
+++ b/sample/src/main/java/com/sys1yagi/mastodon4j/sample/StreamPublicTimeline.java
@@ -7,14 +7,13 @@ import com.sys1yagi.mastodon4j.api.Shutdownable;
 import com.sys1yagi.mastodon4j.api.entity.Notification;
 import com.sys1yagi.mastodon4j.api.entity.Status;
 import com.sys1yagi.mastodon4j.api.method.Streaming;
-import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
 
 public class StreamPublicTimeline {
     public static void main(String[] args) {
         // require authentication even if public streaming
         String accessToken = "PUT YOUR ACCESS TOKEN";
-        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson())
+        MastodonClient client = new MastodonClient.Builder("mstdn.jp", new Gson())
                 .accessToken(accessToken)
                 .useStreamingApi()
                 .build();


### PR DESCRIPTION
This PR deals with:

- OkHttp leakage described in #5
  - creating an OkHttp instance ourselves is no longer necessary when building a MastodonClient
  - users of `Media.postMedia()` will still have to deal with `okhttp3.MultipartBody`. Currently unsure if this is worth hiding and if so, how
- hardcoded path prefixes described in #35
  - it is now possible to call endpoints other than `/api/v1/...` - necessary for OAuth and later for V2 endpoints
  - method `postUrl()` allowing to post to arbitrary URLs was removed
  - URLs are now mostly created via `okhttp3.HttpUrl`, parameter lists via our own `Parameter` intead of as strings directly

Please review, because this has changes all over the place.