### PR TITLE
Updated .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Move Kotlin source to the directory they belong to
 bd9206d09dca091d9109334184713c64691cd437
+
+# Renamed library from Mastodon4J to Bigbone
+ad53d87aaf1a8674d9ac42d3a954a13376466125


### PR DESCRIPTION
The library was renamed from Mastodon4J to Bigbone. This was a big change affecting almost every file in the repo. In order to not make it pollute the git blame info, I've added that particular commit to this file.