### PR TITLE
MastodonClient refactoring

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -36,7 +36,7 @@ To access the API of a Mastodon server, we first need to create client credentia
 __Kotlin__
 
 ```kotlin
-val client: MastodonClient = MastodonClient.Builder(instanceHostname, OkHttpClient.Builder(), Gson()).build()
+val client: MastodonClient = MastodonClient.Builder(instanceHostname).build()
 val apps = Apps(client)
 val appRegistration = apps.createApp(
 	clientName = "bigbone-sample-app",
@@ -49,7 +49,7 @@ val appRegistration = apps.createApp(
 __Java__
 
 ```java
-MastodonClient client = new MastodonClient.Builder(instanceHostname, new OkHttpClient.Builder(), new Gson()).build();
+MastodonClient client = new MastodonClient.Builder(instanceHostname).build();
 Apps apps = new Apps(client);
 try {
 	AppRegistration appRegistration = apps.createApp(
@@ -102,7 +102,7 @@ __Kotlin__
 
 ```kotlin
 // creating a new client using previously received access token
-val client: MastodonClient = MastodonClient.Builder(instanceHostname, OkHttpClient.Builder(), Gson())
+val client: MastodonClient = MastodonClient.Builder(instanceHostname)
 	.accessToken(accessToken)
 	.build()
 
@@ -189,7 +189,7 @@ v1.0.0 or later
 __Kotlin__
 
 ```kotlin
-val client: MastodonClient = MastodonClient.Builder(instanceHostname, OkHttpClient.Builder(), Gson())
+val client: MastodonClient = MastodonClient.Builder(instanceHostname)
   .accessToken(accessToken)
   .useStreamingApi()
   .build()
@@ -215,7 +215,7 @@ try {
 __Java__
 
 ```java
-MastodonClient client = new MastodonClient.Builder(instanceHostname, new OkHttpClient.Builder(), new Gson())
+MastodonClient client = new MastodonClient.Builder(instanceHostname)
         .accessToken(accessToken)
         .useStreamingApi()
         .build();

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -1,12 +1,16 @@
 package social.bigbone
 
 import com.google.gson.Gson
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import social.bigbone.api.exception.BigboneRequestException
+import social.bigbone.extension.emptyRequestBody
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -17,14 +21,13 @@ private constructor(
     private val gson: Gson
 ) {
     private var debug = false
-    val baseUrl = "https://$instanceName"
 
     class Builder(
-        private val instanceName: String,
-        private val okHttpClientBuilder: OkHttpClient.Builder,
-        private val gson: Gson
+        private val instanceName: String
     ) {
 
+        private val okHttpClientBuilder = OkHttpClient.Builder()
+        private val gson = Gson()
         private var accessToken: String? = null
         private var debug = false
 
@@ -51,9 +54,9 @@ private constructor(
         }
     }
 
-    fun debugPrint(log: String) {
+    private fun debugPrintUrl(url: HttpUrl) {
         if (debug) {
-            println(log)
+            println(url.toUrl().toString())
         }
     }
 
@@ -78,16 +81,18 @@ private constructor(
 
     open fun getInstanceName() = instanceName
 
-    open fun get(path: String, parameter: Parameter? = null): Response {
+    /**
+     * Get a response from the Mastodon instance defined for this client using the GET method.
+     * @param path an absolute path to the API endpoint to call
+     * @param query the parameters to use as query string for this request; may be null
+     */
+    open fun get(path: String, query: Parameter? = null): Response {
         try {
-            val url = "$baseUrl/$path"
-            debugPrint(url)
-            val urlWithParams = parameter?.let {
-                "$url?${it.build()}"
-            } ?: url
+            val url = fullUrl(instanceName, path, query)
+            debugPrintUrl(url)
             val call = client.newCall(
                 Request.Builder()
-                    .url(urlWithParams)
+                    .url(url)
                     .get()
                     .build()
             )
@@ -97,9 +102,26 @@ private constructor(
         }
     }
 
-    open fun postUrl(url: String, body: RequestBody): Response {
+    /**
+     * Get a response from the Mastodon instance defined for this client using the POST method.
+     * @param path an absolute path to the API endpoint to call
+     * @param body the parameters to use in the request body for this request; may be null
+     */
+    open fun post(path: String, body: Parameter? = null): Response =
+        postRequestBody(path, parameterBody(body))
+
+    /**
+     * Get a response from the Mastodon instance defined for this client using the POST method. Use this method if
+     * you need to build your own RequestBody; see post() otherwise.
+     * @param path an absolute path to the API endpoint to call
+     * @param body the RequestBody to use for this request
+     *
+     * @see post
+     */
+    open fun postRequestBody(path: String, body: RequestBody): Response {
         try {
-            debugPrint(url)
+            val url = fullUrl(instanceName, path)
+            debugPrintUrl(url)
             val call = client.newCall(
                 Request.Builder()
                     .url(url)
@@ -114,17 +136,19 @@ private constructor(
         }
     }
 
-    open fun post(path: String, body: RequestBody) =
-        postUrl("$baseUrl/$path", body)
-
-    open fun patch(path: String, body: RequestBody): Response {
+    /**
+     * Get a response from the Mastodon instance defined for this client using the PATCH method.
+     * @param path an absolute path to the API endpoint to call
+     * @param body the parameters to use in the request body for this request
+     */
+    open fun patch(path: String, body: Parameter): Response {
         try {
-            val url = "$baseUrl/$path"
-            debugPrint(url)
+            val url = fullUrl(instanceName, path)
+            debugPrintUrl(url)
             val call = client.newCall(
                 Request.Builder()
                     .url(url)
-                    .patch(body)
+                    .patch(parameterBody(body))
                     .build()
             )
             return call.execute()
@@ -133,10 +157,14 @@ private constructor(
         }
     }
 
+    /**
+     * Get a response from the Mastodon instance defined for this client using the DELETE method.
+     * @param path an absolute path to the API endpoint to call
+     */
     open fun delete(path: String): Response {
         try {
-            val url = "$baseUrl/$path"
-            debugPrint(url)
+            val url = fullUrl(instanceName, path)
+            debugPrintUrl(url)
             val call = client.newCall(
                 Request.Builder()
                     .url(url)
@@ -146,6 +174,36 @@ private constructor(
             return call.execute()
         } catch (e: IOException) {
             throw BigboneRequestException(e)
+        }
+    }
+
+    companion object {
+        /**
+         * Returns a HttpUrl
+         * @param instanceName host of a Mastodon instance
+         * @param path Mastodon API endpoint to be called
+         * @param query query part of the URL to build; may be null
+         */
+        fun fullUrl(instanceName: String, path: String, query: Parameter? = null): HttpUrl {
+            val urlBuilder = HttpUrl.Builder()
+                .scheme("https")
+                .host(instanceName)
+                .addEncodedPathSegments(path)
+            query?.let {
+                urlBuilder.encodedQuery(it.build())
+            }
+            return urlBuilder.build()
+        }
+
+        /**
+         * Returns a RequestBody matching the given parameters.
+         * @param parameters list of parameters to use; may be null, in which case the returned RequestBody will be empty
+         */
+        fun parameterBody(parameters: Parameter?): RequestBody {
+            return parameters
+                ?.build()
+                ?.toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
+                ?: emptyRequestBody()
         }
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Accounts.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Accounts.kt
@@ -1,7 +1,5 @@
 package social.bigbone.api.method
 
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameter
@@ -10,7 +8,6 @@ import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.api.entity.Relationship
 import social.bigbone.api.entity.Status
-import social.bigbone.extension.emptyRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#accounts
@@ -53,14 +50,10 @@ class Accounts(private val client: MastodonClient) {
             header?.let {
                 append("header", it)
             }
-        }.build()
+        }
         return MastodonRequest(
             {
-                client.patch(
-                    "api/v1/accounts/update_credentials",
-                    parameters
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                )
+                client.patch("api/v1/accounts/update_credentials", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Account::class.java)
@@ -136,7 +129,7 @@ class Accounts(private val client: MastodonClient) {
     fun postFollow(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("api/v1/accounts/$accountId/follow", emptyRequestBody())
+                client.post("api/v1/accounts/$accountId/follow")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -148,7 +141,7 @@ class Accounts(private val client: MastodonClient) {
     fun postUnFollow(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("api/v1/accounts/$accountId/unfollow", emptyRequestBody())
+                client.post("api/v1/accounts/$accountId/unfollow")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -160,7 +153,7 @@ class Accounts(private val client: MastodonClient) {
     fun postBlock(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("api/v1/accounts/$accountId/block", emptyRequestBody())
+                client.post("api/v1/accounts/$accountId/block")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -172,7 +165,7 @@ class Accounts(private val client: MastodonClient) {
     fun postUnblock(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("api/v1/accounts/$accountId/unblock", emptyRequestBody())
+                client.post("api/v1/accounts/$accountId/unblock")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -184,7 +177,7 @@ class Accounts(private val client: MastodonClient) {
     fun postMute(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("api/v1/accounts/$accountId/mute", emptyRequestBody())
+                client.post("api/v1/accounts/$accountId/mute")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)
@@ -196,7 +189,7 @@ class Accounts(private val client: MastodonClient) {
     fun postUnmute(accountId: Long): MastodonRequest<Relationship> {
         return MastodonRequest<Relationship>(
             {
-                client.post("api/v1/accounts/$accountId/unmute", emptyRequestBody())
+                client.post("api/v1/accounts/$accountId/unmute")
             },
             {
                 client.getSerializer().fromJson(it, Relationship::class.java)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/FollowRequests.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/FollowRequests.kt
@@ -6,7 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.api.exception.BigboneRequestException
-import social.bigbone.extension.emptyRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#follow-requests
@@ -26,7 +25,7 @@ class FollowRequests(private val client: MastodonClient) {
     //  POST /api/v1/follow_requests/:id/authorize
     @Throws(BigboneRequestException::class)
     fun postAuthorize(accountId: Long) {
-        val response = client.post("api/v1/follow_requests/$accountId/authorize", emptyRequestBody())
+        val response = client.post("api/v1/follow_requests/$accountId/authorize")
         if (!response.isSuccessful) {
             throw BigboneRequestException(response)
         }
@@ -35,7 +34,7 @@ class FollowRequests(private val client: MastodonClient) {
     //  POST /api/v1/follow_requests/:id/reject
     @Throws(BigboneRequestException::class)
     fun postReject(accountId: Long) {
-        val response = client.post("api/v1/follow_requests/$accountId/reject", emptyRequestBody())
+        val response = client.post("api/v1/follow_requests/$accountId/reject")
         if (!response.isSuccessful) {
             throw BigboneRequestException(response)
         }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Follows.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Follows.kt
@@ -1,7 +1,5 @@
 package social.bigbone.api.method
 
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameter
@@ -18,14 +16,9 @@ class Follows(private val client: MastodonClient) {
     fun postRemoteFollow(uri: String): MastodonRequest<Account> {
         val parameters = Parameter()
             .append("uri", uri)
-            .build()
         return MastodonRequest<Account>(
             {
-                client.post(
-                    "api/v1/follows",
-                    parameters
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                )
+                client.post("api/v1/follows", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Account::class.java)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
@@ -17,7 +17,7 @@ class Media(private val client: MastodonClient) {
             .build()
         return MastodonRequest<Attachment>(
             {
-                client.post("api/v1/media", requestBody)
+                client.postRequestBody("api/v1/media", requestBody)
             },
             {
                 client.getSerializer().fromJson(it, Attachment::class.java)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Notifications.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Notifications.kt
@@ -6,7 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Notification
 import social.bigbone.api.exception.BigboneRequestException
-import social.bigbone.extension.emptyRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#notifications
@@ -47,10 +46,7 @@ class Notifications(private val client: MastodonClient) {
     //  POST /api/v1/notifications/clear
     @Throws(BigboneRequestException::class)
     fun clearNotifications() {
-        val response = client.post(
-            "api/v1/notifications/clear",
-            emptyRequestBody()
-        )
+        val response = client.post("api/v1/notifications/clear")
         if (!response.isSuccessful) {
             throw BigboneRequestException(response)
         }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Reports.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Reports.kt
@@ -1,7 +1,5 @@
 package social.bigbone.api.method
 
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameter
@@ -43,14 +41,10 @@ class Reports(private val client: MastodonClient) {
             append("account_id", accountId)
             append("status_ids", statusId)
             append("comment", comment)
-        }.build()
+        }
         return MastodonRequest<Report>(
             {
-                client.post(
-                    "api/v1/reports",
-                    parameters
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                )
+                client.post("api/v1/reports", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Report::class.java)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Statuses.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Statuses.kt
@@ -1,7 +1,5 @@
 package social.bigbone.api.method
 
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameter
@@ -12,7 +10,6 @@ import social.bigbone.api.entity.Card
 import social.bigbone.api.entity.Context
 import social.bigbone.api.entity.Status
 import social.bigbone.api.exception.BigboneRequestException
-import social.bigbone.extension.emptyRequestBody
 
 /**
  * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#statuses
@@ -124,15 +121,11 @@ class Statuses(private val client: MastodonClient) {
                 append("spoiler_text", it)
             }
             append("visibility", visibility.value)
-        }.build()
+        }
 
         return MastodonRequest<Status>(
             {
-                client.post(
-                    "api/v1/statuses",
-                    parameters
-                        .toRequestBody("application/x-www-form-urlencoded; charset=utf-8".toMediaTypeOrNull())
-                )
+                client.post("api/v1/statuses", parameters)
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -154,7 +147,7 @@ class Statuses(private val client: MastodonClient) {
     fun postReblog(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("api/v1/statuses/$statusId/reblog", emptyRequestBody())
+                client.post("api/v1/statuses/$statusId/reblog")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -167,7 +160,7 @@ class Statuses(private val client: MastodonClient) {
     fun postUnreblog(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("api/v1/statuses/$statusId/unreblog", emptyRequestBody())
+                client.post("api/v1/statuses/$statusId/unreblog")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -180,7 +173,7 @@ class Statuses(private val client: MastodonClient) {
     fun postFavourite(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("api/v1/statuses/$statusId/favourite", emptyRequestBody())
+                client.post("api/v1/statuses/$statusId/favourite")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)
@@ -193,7 +186,7 @@ class Statuses(private val client: MastodonClient) {
     fun postUnfavourite(statusId: Long): MastodonRequest<Status> {
         return MastodonRequest<Status>(
             {
-                client.post("api/v1/statuses/$statusId/unfavourite", emptyRequestBody())
+                client.post("api/v1/statuses/$statusId/unfavourite")
             },
             {
                 client.getSerializer().fromJson(it, Status::class.java)

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AppsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AppsTest.kt
@@ -45,7 +45,7 @@ class AppsTest {
 
         val url = Apps(client).getOAuthUrl("client_id", Scope(Scope.Name.ALL))
         url shouldBeEqualTo "https://mastodon.cloud/oauth/authorize?client_id=client_id" +
-            "&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=read write follow"
+            "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write+follow"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
@@ -44,7 +44,7 @@ object MockClient {
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
-        every { clientMock.postUrl(ofType<String>(), any()) } returns response
+        every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()
         return clientMock
@@ -71,7 +71,7 @@ object MockClient {
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
-        every { clientMock.postUrl(ofType<String>(), any()) } returns response
+        every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()
         return clientMock

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
@@ -1,7 +1,5 @@
 package social.bigbone.sample
 
-import com.google.gson.Gson
-import okhttp3.OkHttpClient
 import social.bigbone.MastodonClient
 import social.bigbone.api.Scope
 import social.bigbone.api.entity.auth.AccessToken
@@ -54,7 +52,7 @@ object Authenticator {
         } else {
             println("access token found...")
         }
-        return MastodonClient.Builder(instanceName, OkHttpClient.Builder(), Gson())
+        return MastodonClient.Builder(instanceName)
             .accessToken(properties[ACCESS_TOKEN].toString())
             .apply {
                 if (useStreaming) {
@@ -71,13 +69,13 @@ object Authenticator {
         email: String,
         password: String
     ): AccessToken {
-        val client = MastodonClient.Builder(instanceName, OkHttpClient.Builder(), Gson()).build()
+        val client = MastodonClient.Builder(instanceName).build()
         val apps = Apps(client)
         return apps.postUserNameAndPassword(clientId, clientSecret, Scope(), email, password).execute()
     }
 
     private fun appRegistration(instanceName: String): AppRegistration {
-        val client = MastodonClient.Builder(instanceName, OkHttpClient.Builder(), Gson()).build()
+        val client = MastodonClient.Builder(instanceName).build()
         val apps = Apps(client)
         return apps.createApp(
             "kotlindon",

--- a/sample/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample/src/main/java/social/bigbone/sample/Authenticator.java
@@ -1,7 +1,5 @@
 package social.bigbone.sample;
 
-import com.google.gson.Gson;
-import okhttp3.OkHttpClient;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Scope;
 import social.bigbone.api.entity.auth.AccessToken;
@@ -54,7 +52,7 @@ final class Authenticator {
         } else {
             System.out.println("access token found...");
         }
-        final MastodonClient.Builder builder = new MastodonClient.Builder(instanceName, new OkHttpClient.Builder(), new Gson())
+        final MastodonClient.Builder builder = new MastodonClient.Builder(instanceName)
             .accessToken(properties.get(ACCESS_TOKEN).toString());
         if (useStreaming) {
             builder.useStreamingApi();
@@ -63,13 +61,13 @@ final class Authenticator {
     }
 
     private static AccessToken getAccessToken(final String instanceName, final String clientId, final String clientSecret, final String email, final String password) throws BigboneRequestException {
-        final MastodonClient client = new MastodonClient.Builder(instanceName, new OkHttpClient.Builder(), new Gson()).build();
+        final MastodonClient client = new MastodonClient.Builder(instanceName).build();
         final Apps apps = new Apps(client);
         return apps.postUserNameAndPassword(clientId, clientSecret, new Scope(), email, password).execute();
     }
 
     private static AppRegistration appRegistration(final String instanceName) throws BigboneRequestException {
-        final MastodonClient client = new MastodonClient.Builder(instanceName, new OkHttpClient.Builder(), new Gson()).build();
+        final MastodonClient client = new MastodonClient.Builder(instanceName).build();
         final Apps apps = new Apps(client);
         return apps.createApp("kotlindon", "urn:ietf:wg:oauth:2.0:oob", new Scope(), null).execute();
     }

--- a/sample/src/main/java/social/bigbone/sample/GetAppRegistration.java
+++ b/sample/src/main/java/social/bigbone/sample/GetAppRegistration.java
@@ -1,8 +1,5 @@
 package social.bigbone.sample;
 
-
-import com.google.gson.Gson;
-import okhttp3.OkHttpClient;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Scope;
 import social.bigbone.api.entity.auth.AppRegistration;
@@ -12,7 +9,7 @@ import social.bigbone.api.method.Apps;
 @SuppressWarnings({"PMD.SystemPrintln", "PMD.AvoidPrintStackTrace"})
 public class GetAppRegistration {
     public static void main(final String[] args) {
-        final MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson()).build();
+        final MastodonClient client = new MastodonClient.Builder("mstdn.jp").build();
         final Apps apps = new Apps(client);
         try {
             final AppRegistration registration = apps.createApp(

--- a/sample/src/main/java/social/bigbone/sample/GetPublicTimelines.java
+++ b/sample/src/main/java/social/bigbone/sample/GetPublicTimelines.java
@@ -1,10 +1,9 @@
 package social.bigbone.sample;
 
-import com.google.gson.Gson;
-import okhttp3.OkHttpClient;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Pageable;
 import social.bigbone.api.Range;
+import social.bigbone.api.entity.Account;
 import social.bigbone.api.entity.Status;
 import social.bigbone.api.exception.BigboneRequestException;
 import social.bigbone.api.method.Public;
@@ -12,7 +11,7 @@ import social.bigbone.api.method.Public;
 @SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.SystemPrintln"})
 public class GetPublicTimelines {
     public static void main(final String[] args) {
-        final MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson()).build();
+        final MastodonClient client = new MastodonClient.Builder("mstdn.jp").build();
         final Public publicMethod = new Public(client);
 
         try {
@@ -21,7 +20,10 @@ public class GetPublicTimelines {
                     .execute();
             statuses.getPart().forEach(status -> {
                 System.out.println("=============");
-                System.out.println(status.getAccount().getDisplayName());
+                final Account account = status.getAccount();
+                if (account != null) {
+                    System.out.println(account.getDisplayName());
+                }
                 System.out.println(status.getContent());
                 System.out.println(status.isReblogged());
             });

--- a/sample/src/main/java/social/bigbone/sample/GetTagTimelines.java
+++ b/sample/src/main/java/social/bigbone/sample/GetTagTimelines.java
@@ -1,10 +1,9 @@
 package social.bigbone.sample;
 
-import com.google.gson.Gson;
-import okhttp3.OkHttpClient;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Pageable;
 import social.bigbone.api.Range;
+import social.bigbone.api.entity.Account;
 import social.bigbone.api.entity.Status;
 import social.bigbone.api.method.Public;
 import social.bigbone.api.exception.BigboneRequestException;
@@ -12,14 +11,17 @@ import social.bigbone.api.exception.BigboneRequestException;
 @SuppressWarnings({"PMD.SystemPrintln", "PMD.AvoidPrintStackTrace"})
 public class GetTagTimelines {
     public static void main(final String[] args) {
-        final MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson()).build();
+        final MastodonClient client = new MastodonClient.Builder("mstdn.jp").build();
         final Public publicMethod = new Public(client);
 
         try {
             final Pageable<Status> statuses = publicMethod.getFederatedTag("mastodon", new Range()).execute();
             statuses.getPart().forEach(status -> {
                 System.out.println("=============");
-                System.out.println(status.getAccount().getDisplayName());
+                final Account account = status.getAccount();
+                if (account != null) {
+                    System.out.println(account.getDisplayName());
+                }
                 System.out.println(status.getContent());
                 System.out.println(status.isReblogged());
             });

--- a/sample/src/main/java/social/bigbone/sample/StreamPublicTimeline.java
+++ b/sample/src/main/java/social/bigbone/sample/StreamPublicTimeline.java
@@ -1,7 +1,5 @@
 package social.bigbone.sample;
 
-import com.google.gson.Gson;
-import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Handler;
@@ -16,7 +14,7 @@ public class StreamPublicTimeline {
     public static void main(final String[] args) {
         // require authentication even if public streaming
         final String accessToken = "PUT YOUR ACCESS TOKEN";
-        final MastodonClient client = new MastodonClient.Builder("mstdn.jp", new OkHttpClient.Builder(), new Gson())
+        final MastodonClient client = new MastodonClient.Builder("mstdn.jp")
                 .accessToken(accessToken)
                 .useStreamingApi()
                 .build();


### PR DESCRIPTION
This refactors `MastodonClient` including API method classes using it, and related functionality to achieve the following:

- remove OkHttp3 and Gson instances from MastodonClient.Builder as unnecessary exposure of implementation details (closes #5)
- build all endpoint URLs using OkHttp3.HttpUrl instead of string concatenation (closes #48)
- remove the MastodonClient.postUrl() special case after endpoint path prefix is no longer hardcoded (closes #49).