### PR TITLE
remove postUserNameAndPassword()

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxApps.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxApps.kt
@@ -43,27 +43,4 @@ class RxApps(client: MastodonClient) {
             }
         }
     }
-
-    @Deprecated(
-        "This method uses grant_type 'password' which is undocumented in Mastodon API" +
-            " and should not be used in production code.",
-        ReplaceWith("getAccessToken()"),
-        DeprecationLevel.WARNING
-    )
-    fun postUserNameAndPassword(
-        clientId: String,
-        clientSecret: String,
-        scope: Scope,
-        userName: String,
-        password: String
-    ): Single<AccessToken> {
-        return Single.create {
-            try {
-                val accessToken = apps.postUserNameAndPassword(clientId, clientSecret, scope, userName, password)
-                it.onSuccess(accessToken.execute())
-            } catch (throwable: Throwable) {
-                it.onErrorIfNotDisposed(throwable)
-            }
-        }
-    }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Apps.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Apps.kt
@@ -97,39 +97,4 @@ class Apps(private val client: MastodonClient) {
             }
         )
     }
-
-    /**
-     * Obtain an access token, to be used during API calls that are not public. This method uses a grant_type
-     * that is undocumented in Mastodon API, and should NOT be used in production code. It exists for example code
-     * in this project and will be removed at a later date. getAccessToken() should be used instead.
-     */
-    @Deprecated(
-        "This method uses grant_type 'password' which is undocumented in Mastodon API" +
-            " and should not be used in production code.",
-        ReplaceWith("getAccessToken()"),
-        DeprecationLevel.WARNING
-    )
-    fun postUserNameAndPassword(
-        clientId: String,
-        clientSecret: String,
-        scope: Scope,
-        userName: String,
-        password: String
-    ): MastodonRequest<AccessToken> {
-        val parameters = Parameter()
-            .append("client_id", clientId)
-            .append("client_secret", clientSecret)
-            .append("scope", scope.toString())
-            .append("username", userName)
-            .append("password", password)
-            .append("grant_type", "password")
-        return MastodonRequest(
-            {
-                client.post("oauth/token", parameters)
-            },
-            {
-                client.getSerializer().fromJson(it, AccessToken::class.java)
-            }
-        )
-    }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AppsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AppsTest.kt
@@ -69,26 +69,4 @@ class AppsTest {
             apps.getAccessToken("test", "test", code = "test").execute()
         }
     }
-
-    @Test
-    fun postUserNameAndPassword() {
-        val client: MastodonClient = MockClient.mock("access_token.json")
-        every { client.getInstanceName() } returns "mastodon.cloud"
-        val apps = Apps(client)
-        val accessToken = apps.postUserNameAndPassword("test", "test", Scope(Scope.Name.ALL), "test", "test").execute()
-        accessToken.accessToken shouldBeEqualTo "test"
-        accessToken.scope shouldBeEqualTo "read write follow"
-        accessToken.tokenType shouldBeEqualTo "bearer"
-        accessToken.createdAt shouldBeEqualTo 1_493_188_835
-    }
-
-    @Test
-    fun postUserNameAndPasswordWithException() {
-        Assertions.assertThrows(BigboneRequestException::class.java) {
-            val client: MastodonClient = MockClient.ioException()
-            every { client.getInstanceName() } returns "mastodon.cloud"
-            val apps = Apps(client)
-            apps.postUserNameAndPassword("test", "test", Scope(Scope.Name.ALL), "test", "test").execute()
-        }
-    }
 }


### PR DESCRIPTION
This removes postUserNameAndPassword() from our public API, which performed OAuth using a grant type not officially supported by Mastodon API (issue #11). Unsupported functionality was temporarily moved into the sample apps, pending a rewrite of those at a later time.

2.0.0 milestone should be removed from #11 if we want to keep that open for the pending sample apps rewrite - or a new issue be opened for that to close #11.