### PR TITLE
wrapper functions for endpoint calls

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Accounts.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Accounts.kt
@@ -15,17 +15,17 @@ import social.bigbone.api.entity.Status
 class Accounts(private val client: MastodonClient) {
     // GET /api/v1/accounts/:id
     fun getAccount(accountId: String): MastodonRequest<Account> {
-        return MastodonRequest(
-            { client.get("api/v1/accounts/$accountId") },
-            { client.getSerializer().fromJson(it, Account::class.java) }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId",
+            method = MastodonClient.Method.GET
         )
     }
 
     //  GET /api/v1/accounts/verify_credentials
     fun getVerifyCredentials(): MastodonRequest<Account> {
-        return MastodonRequest(
-            { client.get("api/v1/accounts/verify_credentials") },
-            { client.getSerializer().fromJson(it, Account::class.java) }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/verify_credentials",
+            method = MastodonClient.Method.GET
         )
     }
 
@@ -37,26 +37,14 @@ class Accounts(private val client: MastodonClient) {
      * header: A base64 encoded image to display as the user's header image (e.g. data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...)
      */
     fun updateCredential(displayName: String?, note: String?, avatar: String?, header: String?): MastodonRequest<Account> {
-        val parameters = Parameter().apply {
-            displayName?.let {
-                append("display_name", it)
-            }
-            note?.let {
-                append("note", it)
-            }
-            avatar?.let {
-                append("avatar", it)
-            }
-            header?.let {
-                append("header", it)
-            }
-        }
-        return MastodonRequest(
-            {
-                client.patch("api/v1/accounts/update_credentials", parameters)
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/update_credentials",
+            method = MastodonClient.Method.PATCH,
+            parameters = Parameter().apply {
+                displayName?.let { append("display_name", it) }
+                note?.let { append("note", it) }
+                avatar?.let { append("avatar", it) }
+                header?.let { append("header", it) }
             }
         )
     }
@@ -64,33 +52,21 @@ class Accounts(private val client: MastodonClient) {
     //  GET /api/v1/accounts/:id/followers
     @JvmOverloads
     fun getFollowers(accountId: String, range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            {
-                client.get(
-                    "api/v1/accounts/$accountId/followers",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/followers",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 
     //  GET /api/v1/accounts/:id/following
     @JvmOverloads
     fun getFollowing(accountId: String, range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            {
-                client.get(
-                    "api/v1/accounts/$accountId/following",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/following",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 
     //  GET /api/v1/accounts/:id/statuses
@@ -102,113 +78,71 @@ class Accounts(private val client: MastodonClient) {
         pinned: Boolean = false,
         range: Range = Range()
     ): MastodonRequest<Pageable<Status>> {
-        val parameters = range.toParameter()
-        if (onlyMedia) {
-            parameters.append("only_media", true)
-        }
-        if (pinned) {
-            parameters.append("pinned", true)
-        }
-        if (excludeReplies) {
-            parameters.append("exclude_replies", true)
-        }
-        return MastodonRequest<Pageable<Status>>(
-            {
-                client.get(
-                    "api/v1/accounts/$accountId/statuses",
-                    parameters
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/statuses",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter().apply {
+                if (onlyMedia) { append("only_media", true) }
+                if (pinned) { append("pinned", true) }
+                if (excludeReplies) { append("exclude_replies", true) }
             }
-        ).toPageable()
+        )
     }
 
     //  POST /api/v1/accounts/:id/follow
     fun postFollow(accountId: String): MastodonRequest<Relationship> {
-        return MastodonRequest<Relationship>(
-            {
-                client.post("api/v1/accounts/$accountId/follow")
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/follow",
+            method = MastodonClient.Method.POST,
         )
     }
 
     //  POST /api/v1/accounts/:id/unfollow
     fun postUnFollow(accountId: String): MastodonRequest<Relationship> {
-        return MastodonRequest<Relationship>(
-            {
-                client.post("api/v1/accounts/$accountId/unfollow")
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/unfollow",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/accounts/:id/block
     fun postBlock(accountId: String): MastodonRequest<Relationship> {
-        return MastodonRequest<Relationship>(
-            {
-                client.post("api/v1/accounts/$accountId/block")
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/block",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/accounts/:id/unblock
     fun postUnblock(accountId: String): MastodonRequest<Relationship> {
-        return MastodonRequest<Relationship>(
-            {
-                client.post("api/v1/accounts/$accountId/unblock")
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/unblock",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/accounts/:id/mute
     fun postMute(accountId: String): MastodonRequest<Relationship> {
-        return MastodonRequest<Relationship>(
-            {
-                client.post("api/v1/accounts/$accountId/mute")
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/mute",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/accounts/:id/unmute
     fun postUnmute(accountId: String): MastodonRequest<Relationship> {
-        return MastodonRequest<Relationship>(
-            {
-                client.post("api/v1/accounts/$accountId/unmute")
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/accounts/$accountId/unmute",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  GET /api/v1/accounts/relationships
     fun getRelationships(accountIds: List<String>): MastodonRequest<List<Relationship>> {
-        return MastodonRequest(
-            {
-                client.get(
-                    "api/v1/accounts/relationships",
-                    Parameter().append("id", accountIds)
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Relationship::class.java)
-            }
+        return client.getMastodonRequestForList(
+            endpoint = "api/v1/accounts/relationships",
+            method = MastodonClient.Method.GET,
+            parameters = Parameter().append("id", accountIds)
         )
     }
 
@@ -219,18 +153,12 @@ class Accounts(private val client: MastodonClient) {
      */
     @JvmOverloads
     fun getAccountSearch(query: String, limit: Int = 40): MastodonRequest<List<Account>> {
-        return MastodonRequest(
-            {
-                client.get(
-                    "api/v1/accounts/search",
-                    Parameter()
-                        .append("q", query)
-                        .append("limit", limit)
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
+        return client.getMastodonRequestForList(
+            endpoint = "api/v1/accounts/search",
+            method = MastodonClient.Method.GET,
+            parameters = Parameter()
+                .append("q", query)
+                .append("limit", limit)
         )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Apps.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Apps.kt
@@ -81,19 +81,15 @@ class Apps(private val client: MastodonClient) {
         code: String,
         grantType: String = "authorization_code"
     ): MastodonRequest<AccessToken> {
-        val parameters = Parameter()
-            .append("client_id", clientId)
-            .append("client_secret", clientSecret)
-            .append("redirect_uri", redirectUri)
-            .append("code", code)
-            .append("grant_type", grantType)
-
-        return MastodonRequest(
-            {
-                client.post("oauth/token", parameters)
-            },
-            {
-                client.getSerializer().fromJson(it, AccessToken::class.java)
+        return client.getMastodonRequest(
+            endpoint = "oauth/token",
+            method = MastodonClient.Method.POST,
+            parameters = Parameter().apply {
+                append("client_id", clientId)
+                append("client_secret", clientSecret)
+                append("redirect_uri", redirectUri)
+                append("code", code)
+                append("grant_type", grantType)
             }
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Blocks.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Blocks.kt
@@ -14,13 +14,10 @@ class Blocks(private val client: MastodonClient) {
     //  GET /api/v1/blocks
     @JvmOverloads
     fun getBlocks(range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            {
-                client.get("api/v1/blocks", range.toParameter())
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/blocks",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Favourites.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Favourites.kt
@@ -14,13 +14,10 @@ class Favourites(private val client: MastodonClient) {
     //  GET /api/v1/favourites
     @JvmOverloads
     fun getFavourites(range: Range = Range()): MastodonRequest<Pageable<Status>> {
-        return MastodonRequest<Pageable<Status>>(
-            {
-                client.get("api/v1/favourites", range.toParameter())
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/favourites",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/FollowRequests.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/FollowRequests.kt
@@ -14,29 +14,28 @@ class FollowRequests(private val client: MastodonClient) {
     // GET /api/v1/follow_requests
     @JvmOverloads
     fun getFollowRequests(range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            { client.get("api/v1/follow_requests", range.toParameter()) },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/follow_requests",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 
     //  POST /api/v1/follow_requests/:id/authorize
     @Throws(BigboneRequestException::class)
     fun postAuthorize(accountId: String) {
-        val response = client.post("api/v1/follow_requests/$accountId/authorize")
-        if (!response.isSuccessful) {
-            throw BigboneRequestException(response)
-        }
+        client.performAction(
+            endpoint = "api/v1/follow_requests/$accountId/authorize",
+            method = MastodonClient.Method.POST
+        )
     }
 
     //  POST /api/v1/follow_requests/:id/reject
     @Throws(BigboneRequestException::class)
     fun postReject(accountId: String) {
-        val response = client.post("api/v1/follow_requests/$accountId/reject")
-        if (!response.isSuccessful) {
-            throw BigboneRequestException(response)
-        }
+        client.performAction(
+            endpoint = "api/v1/follow_requests/$accountId/reject",
+            method = MastodonClient.Method.POST
+        )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/MastodonLists.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/MastodonLists.kt
@@ -12,31 +12,19 @@ class MastodonLists(private val client: MastodonClient) {
 
     // GET /api/v1/lists
     fun getLists(): MastodonRequest<Pageable<MastodonList>> {
-        return MastodonRequest<Pageable<MastodonList>>(
-            {
-                client.get(
-                    "api/v1/lists"
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, MastodonList::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/lists",
+            method = MastodonClient.Method.GET
+        )
     }
 
     // GET /api/v1/timelines/list/:list_id
     @Throws(BigboneRequestException::class)
     fun getListTimeLine(listID: String, range: Range = Range()): MastodonRequest<Pageable<Status>> {
-        return MastodonRequest<Pageable<Status>>(
-            {
-                client.get(
-                    "api/v1/timelines/list/$listID",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/list/$listID",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Mutes.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Mutes.kt
@@ -13,13 +13,10 @@ class Mutes(private val client: MastodonClient) {
     // GET /api/v1/mutes
     @JvmOverloads
     fun getMutes(range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            {
-                client.get("api/v1/mutes", range.toParameter())
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/mutes",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Notifications.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Notifications.kt
@@ -14,41 +14,31 @@ class Notifications(private val client: MastodonClient) {
     // GET /api/v1/notifications
     @JvmOverloads
     fun getNotifications(range: Range = Range(), excludeTypes: List<Notification.Type>? = null): MastodonRequest<Pageable<Notification>> {
-        val parameter = range.toParameter()
-        if (excludeTypes != null) {
-            parameter.append("exclude_types", excludeTypes.map { it.value })
-        }
-        return MastodonRequest<Pageable<Notification>>(
-            {
-                client.get(
-                    "api/v1/notifications",
-                    parameter
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Notification::class.java)
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/notifications",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter().apply {
+                excludeTypes?.let {
+                    append("exclude_types", excludeTypes.map { it.value })
+                }
             }
-        ).toPageable()
+        )
     }
 
     // GET /api/v1/notifications/:id
     fun getNotification(id: String): MastodonRequest<Notification> {
-        return MastodonRequest<Notification>(
-            {
-                client.get("api/v1/notifications/$id")
-            },
-            {
-                client.getSerializer().fromJson(it, Notification::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/notifications/$id",
+            method = MastodonClient.Method.GET
         )
     }
 
     //  POST /api/v1/notifications/clear
     @Throws(BigboneRequestException::class)
     fun clearNotifications() {
-        val response = client.post("api/v1/notifications/clear")
-        if (!response.isSuccessful) {
-            throw BigboneRequestException(response)
-        }
+        client.performAction(
+            endpoint = "api/v1/notifications/clear",
+            method = MastodonClient.Method.POST
+        )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Public.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Public.kt
@@ -17,13 +17,9 @@ class Public(private val client: MastodonClient) {
      * @see https://docs.joinmastodon.org/entities/V1_Instance/
      */
     fun getInstance(): MastodonRequest<Instance> {
-        return MastodonRequest(
-            {
-                client.get("api/v1/instance")
-            },
-            { json ->
-                client.getSerializer().fromJson(json, Instance::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/instance",
+            method = MastodonClient.Method.GET
         )
     }
 
@@ -37,20 +33,14 @@ class Public(private val client: MastodonClient) {
      */
     @JvmOverloads
     fun getSearch(query: String, resolve: Boolean = false): MastodonRequest<Results> {
-        return MastodonRequest<Results>(
-            {
-                client.get(
-                    "api/v1/search",
-                    Parameter().apply {
-                        append("q", query)
-                        if (resolve) {
-                            append("resolve", resolve)
-                        }
-                    }
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Results::class.java)
+        return client.getMastodonRequest(
+            endpoint = "api/v1/search",
+            method = MastodonClient.Method.GET,
+            parameters = Parameter().apply {
+                append("q", query)
+                if (resolve) {
+                    append("resolve", true)
+                }
             }
         )
     }
@@ -61,18 +51,15 @@ class Public(private val client: MastodonClient) {
      * @see https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#timelines
      */
     private fun getPublic(local: Boolean, range: Range): MastodonRequest<Pageable<Status>> {
-        val parameter = range.toParameter()
-        if (local) {
-            parameter.append("local", local)
-        }
-        return MastodonRequest<Pageable<Status>>(
-            {
-                client.get("api/v1/timelines/public", parameter)
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/public",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter().apply {
+                if (local) {
+                    append("local", true)
+                }
             }
-        ).toPageable()
+        )
     }
 
     @JvmOverloads
@@ -86,21 +73,15 @@ class Public(private val client: MastodonClient) {
      * @see https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#timelines
      */
     private fun getTag(tag: String, local: Boolean, range: Range): MastodonRequest<Pageable<Status>> {
-        val parameter = range.toParameter()
-        if (local) {
-            parameter.append("local", local)
-        }
-        return MastodonRequest<Pageable<Status>>(
-            {
-                client.get(
-                    "api/v1/timelines/tag/$tag",
-                    parameter
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/tag/$tag",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter().apply {
+                if (local) {
+                    append("local", true)
+                }
             }
-        ).toPageable()
+        )
     }
 
     @JvmOverloads

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Reports.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Reports.kt
@@ -16,17 +16,11 @@ class Reports(private val client: MastodonClient) {
     @JvmOverloads
     @Throws(BigboneRequestException::class)
     fun getReports(range: Range = Range()): MastodonRequest<Pageable<Report>> {
-        return MastodonRequest<Pageable<Report>>(
-            {
-                client.get(
-                    "api/v1/reports",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Report::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/reports",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 
     /**
@@ -37,17 +31,13 @@ class Reports(private val client: MastodonClient) {
      */
     @Throws(BigboneRequestException::class)
     fun postReport(accountId: String, statusId: String, comment: String): MastodonRequest<Report> {
-        val parameters = Parameter().apply {
-            append("account_id", accountId)
-            append("status_ids", statusId)
-            append("comment", comment)
-        }
-        return MastodonRequest<Report>(
-            {
-                client.post("api/v1/reports", parameters)
-            },
-            {
-                client.getSerializer().fromJson(it, Report::class.java)
+        return client.getMastodonRequest(
+            endpoint = "api/v1/reports",
+            method = MastodonClient.Method.POST,
+            parameters = Parameter().apply {
+                append("account_id", accountId)
+                append("status_ids", statusId)
+                append("comment", comment)
             }
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Statuses.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Statuses.kt
@@ -19,39 +19,27 @@ class Statuses(private val client: MastodonClient) {
     //  GET /api/v1/statuses/:id
     @Throws(BigboneRequestException::class)
     fun getStatus(statusId: String): MastodonRequest<Status> {
-        return MastodonRequest<Status>(
-            {
-                client.get("api/v1/statuses/$statusId")
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId",
+            method = MastodonClient.Method.GET
         )
     }
 
     //  GET /api/v1/statuses/:id/context
     @Throws(BigboneRequestException::class)
     fun getContext(statusId: String): MastodonRequest<Context> {
-        return MastodonRequest<Context>(
-            {
-                client.get("api/v1/statuses/$statusId/context")
-            },
-            {
-                client.getSerializer().fromJson(it, Context::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/context",
+            method = MastodonClient.Method.GET
         )
     }
 
     //  GET /api/v1/statuses/:id/card
     @Throws(BigboneRequestException::class)
     fun getCard(statusId: String): MastodonRequest<Card> {
-        return MastodonRequest<Card>(
-            {
-                client.get("api/v1/statuses/$statusId/card")
-            },
-            {
-                client.getSerializer().fromJson(it, Card::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/card",
+            method = MastodonClient.Method.GET
         )
     }
 
@@ -59,34 +47,22 @@ class Statuses(private val client: MastodonClient) {
     @JvmOverloads
     @Throws(BigboneRequestException::class)
     fun getRebloggedBy(statusId: String, range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            {
-                client.get(
-                    "api/v1/statuses/$statusId/reblogged_by",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/reblogged_by",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 
     //  GET /api/v1/favourited_by
     @JvmOverloads
     @Throws(BigboneRequestException::class)
     fun getFavouritedBy(statusId: String, range: Range = Range()): MastodonRequest<Pageable<Account>> {
-        return MastodonRequest<Pageable<Account>>(
-            {
-                client.get(
-                    "api/v1/statuses/$statusId/favourited_by",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Account::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/favourited_by",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 
     /**
@@ -108,27 +84,16 @@ class Statuses(private val client: MastodonClient) {
         spoilerText: String?,
         visibility: Status.Visibility = Status.Visibility.Public
     ): MastodonRequest<Status> {
-        val parameters = Parameter().apply {
-            append("status", status)
-            inReplyToId?.let {
-                append("in_reply_to_id", it)
-            }
-            mediaIds?.let {
-                append("media_ids", it)
-            }
-            append("sensitive", sensitive)
-            spoilerText?.let {
-                append("spoiler_text", it)
-            }
-            append("visibility", visibility.value)
-        }
-
-        return MastodonRequest<Status>(
-            {
-                client.post("api/v1/statuses", parameters)
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses",
+            method = MastodonClient.Method.POST,
+            parameters = Parameter().apply {
+                append("status", status)
+                inReplyToId?.let { append("in_reply_to_id", it) }
+                mediaIds?.let { append("media_ids", it) }
+                append("sensitive", sensitive)
+                spoilerText?.let { append("spoiler_text", it) }
+                append("visibility", visibility.value)
             }
         )
     }
@@ -136,61 +101,45 @@ class Statuses(private val client: MastodonClient) {
     //  DELETE /api/v1/statuses/:id
     @Throws(BigboneRequestException::class)
     fun deleteStatus(statusId: String) {
-        val response = client.delete("api/v1/statuses/$statusId")
-        if (!response.isSuccessful) {
-            throw BigboneRequestException(response)
-        }
+        client.performAction(
+            endpoint = "api/v1/statuses/$statusId",
+            method = MastodonClient.Method.DELETE
+        )
     }
 
     //  POST /api/v1/statuses/:id/reblog
     @Throws(BigboneRequestException::class)
     fun postReblog(statusId: String): MastodonRequest<Status> {
-        return MastodonRequest<Status>(
-            {
-                client.post("api/v1/statuses/$statusId/reblog")
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/reblog",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/statuses/:id/unreblog
     @Throws(BigboneRequestException::class)
     fun postUnreblog(statusId: String): MastodonRequest<Status> {
-        return MastodonRequest<Status>(
-            {
-                client.post("api/v1/statuses/$statusId/unreblog")
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/unreblog",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/statuses/:id/favourite
     @Throws(BigboneRequestException::class)
     fun postFavourite(statusId: String): MastodonRequest<Status> {
-        return MastodonRequest<Status>(
-            {
-                client.post("api/v1/statuses/$statusId/favourite")
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/favourite",
+            method = MastodonClient.Method.POST
         )
     }
 
     //  POST /api/v1/statuses/:id/unfavourite
     @Throws(BigboneRequestException::class)
     fun postUnfavourite(statusId: String): MastodonRequest<Status> {
-        return MastodonRequest<Status>(
-            {
-                client.post("api/v1/statuses/$statusId/unfavourite")
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/unfavourite",
+            method = MastodonClient.Method.POST
         )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Timelines.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Timelines.kt
@@ -15,16 +15,10 @@ class Timelines(private val client: MastodonClient) {
     @JvmOverloads
     @Throws(BigboneRequestException::class)
     fun getHome(range: Range = Range()): MastodonRequest<Pageable<Status>> {
-        return MastodonRequest<Pageable<Status>>(
-            {
-                client.get(
-                    "api/v1/timelines/home",
-                    range.toParameter()
-                )
-            },
-            {
-                client.getSerializer().fromJson(it, Status::class.java)
-            }
-        ).toPageable()
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/home",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
     }
 }


### PR DESCRIPTION
Replace direct use of DELETE/GET/PATCH/POST functions with getMastodonRequest() and related functions where possible, reducing exposure of Gson serializer.

Some special cases remain:
- Media.kt
- Streaming.kt
- postUserNameAndPassword() in sample apps

After cleanup of those and related tests, Gson instance no longer needs to be exposed via MastodonClient.getSerializer, and #51 can be closed.