### PR TITLE
Enable local, remote or combined results when getting timelines

### DIFF
--- a/API.md
+++ b/API.md
@@ -283,13 +283,13 @@ https://docs.joinmastodon.org/methods/scheduled_statuses/
 
 https://docs.joinmastodon.org/methods/timelines/
 
-| Method                                | Description                       | Status | Comments                                                                                                              | 
-|---------------------------------------|-----------------------------------|--------|-----------------------------------------------------------------------------------------------------------------------|
-| `GET /api/v1/timelines/public`        | View public timelines             | 🟠     | `remote`, `only_media`, `min_id` query parameters missing. `Status` entity needs to be updated.                       |
-| `GET /api/v1/timelines/tag/:hashtag`  | View hashtag timeline             | 🟠     | `any`, `all`, `none`, `remote`, `only_media`, `min_id` query parameters missing. `Status` entity needs to be updated. |
-| `GET /api/v1/timelines/home`          | View home timeline                | 🟠     | `min_id` query parameter missing. `Status` entity needs to be updated.                                                |
-| `GET /api/v1/timelines/list/:list_id` | View list timeline                | 🔴     |                                                                                                                       |
-| `GET /api/v1/timelines/direct`        | (DEPRECATED) View direct timeline | 🔴     |                                                                                                                       |
+| Method                                | Description                       | Status | Comments                                                                                                            | 
+|---------------------------------------|-----------------------------------|--------|---------------------------------------------------------------------------------------------------------------------|
+| `GET /api/v1/timelines/public`        | View public timelines             | 🟠     | `only_media`, `min_id` query parameters missing. `Status` entity needs to be updated.                       |
+| `GET /api/v1/timelines/tag/:hashtag`  | View hashtag timeline             | 🟠     | `any`, `all`, `none`, `only_media`, `min_id` query parameters missing. `Status` entity needs to be updated. |
+| `GET /api/v1/timelines/home`          | View home timeline                | 🟠     | `min_id` query parameter missing. `Status` entity needs to be updated.                                              |
+| `GET /api/v1/timelines/list/:list_id` | View list timeline                | 🔴     |                                                                                                                     |
+| `GET /api/v1/timelines/direct`        | (DEPRECATED) View direct timeline | 🔴     |                                                                                                                     |
 
 #### Conversations
 

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxPublic.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxPublic.kt
@@ -12,7 +12,7 @@ import social.bigbone.rx.extensions.onErrorIfNotDisposed
 import social.bigbone.rx.extensions.single
 
 class RxPublic(client: MastodonClient) {
-    val publicMethod = Public(client)
+    private val publicMethod = Public(client)
 
     fun getInstance(): Single<Instance> {
         return Single.create {
@@ -36,27 +36,22 @@ class RxPublic(client: MastodonClient) {
         }
     }
 
-    fun getLocalPublic(range: Range = Range()): Single<Pageable<Status>> {
+    fun getPublic(
+        range: Range = Range(),
+        statusOrigin: Public.StatusOrigin = Public.StatusOrigin.LOCAL_AND_REMOTE
+    ): Single<Pageable<Status>> {
         return single {
-            publicMethod.getLocalPublic(range).execute()
+            publicMethod.getPublic(range, statusOrigin).execute()
         }
     }
 
-    fun getFederatedPublic(range: Range = Range()): Single<Pageable<Status>> {
+    fun getTag(
+        tag: String,
+        range: Range = Range(),
+        statusOrigin: Public.StatusOrigin = Public.StatusOrigin.LOCAL_AND_REMOTE
+    ): Single<Pageable<Status>> {
         return single {
-            publicMethod.getFederatedPublic(range).execute()
-        }
-    }
-
-    fun getLocalTag(tag: String, range: Range = Range()): Single<Pageable<Status>> {
-        return single {
-            publicMethod.getLocalTag(tag, range).execute()
-        }
-    }
-
-    fun getFederatedTag(tag: String, range: Range = Range()): Single<Pageable<Status>> {
-        return single {
-            publicMethod.getFederatedTag(tag, range).execute()
+            publicMethod.getTag(tag, range, statusOrigin).execute()
         }
     }
 }

--- a/bigbone-rx/src/test/kotlin/social/bigbone/rx/RxTimelinesTest.kt
+++ b/bigbone-rx/src/test/kotlin/social/bigbone/rx/RxTimelinesTest.kt
@@ -1,6 +1,7 @@
 package social.bigbone.rx
 
 import org.junit.jupiter.api.Test
+import social.bigbone.api.method.Public
 import social.bigbone.rx.testtool.MockClient
 
 class RxTimelinesTest {
@@ -9,7 +10,7 @@ class RxTimelinesTest {
     fun getPublic() {
         val client = MockClient.mock("public_timeline.json", "5", "40")
         val publicMethod = RxPublic(client)
-        val subscriber = publicMethod.getLocalPublic().test()
+        val subscriber = publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).test()
         subscriber.assertNoErrors()
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/PublicTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/PublicTest.kt
@@ -86,7 +86,7 @@ class PublicTest {
     fun getLocalPublic() {
         val client = MockClient.mock("public_timeline.json", maxId = "3", sinceId = "1")
         val publicMethod = Public(client)
-        val statuses = publicMethod.getLocalPublic().execute()
+        val statuses = publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).execute()
         statuses.part.size shouldBeEqualTo 20
         statuses.link?.let {
             it.nextPath shouldBeEqualTo "<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&max_id=3>"
@@ -101,7 +101,7 @@ class PublicTest {
         val atomicInt = AtomicInteger(0)
         val client = MockClient.mock("public_timeline.json", maxId = "3", sinceId = "1")
         val publicMethod = Public(client)
-        publicMethod.getLocalPublic()
+        publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL)
             .doOnJson {
                 atomicInt.incrementAndGet()
             }
@@ -114,7 +114,7 @@ class PublicTest {
         Assertions.assertThrows(BigboneRequestException::class.java) {
             val client = MockClient.ioException()
             val publicMethod = Public(client)
-            publicMethod.getLocalPublic().execute()
+            publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).execute()
         }
     }
 
@@ -122,7 +122,7 @@ class PublicTest {
     fun getLocalTag() {
         val client = MockClient.mock("tag.json", maxId = "3", sinceId = "1")
         val publicMethod = Public(client)
-        val statuses = publicMethod.getLocalTag("mastodon").execute()
+        val statuses = publicMethod.getTag(tag = "mastodon", statusOrigin = Public.StatusOrigin.LOCAL).execute()
         statuses.part.size shouldBeEqualTo 20
     }
 
@@ -131,7 +131,7 @@ class PublicTest {
         Assertions.assertThrows(BigboneRequestException::class.java) {
             val client = MockClient.ioException()
             val publicMethod = Public(client)
-            publicMethod.getLocalTag("mastodon").execute()
+            publicMethod.getTag(tag = "mastodon", statusOrigin = Public.StatusOrigin.LOCAL).execute()
         }
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/GetPublicTimelines.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetPublicTimelines.java
@@ -15,7 +15,7 @@ public class GetPublicTimelines {
         final Public publicMethod = new Public(client);
 
         try {
-            final Pageable<Status> statuses = publicMethod.getLocalPublic(new Range())
+            final Pageable<Status> statuses = publicMethod.getPublic(new Range(), Public.StatusOrigin.LOCAL)
                     .doOnJson(System.out::println)
                     .execute();
             statuses.getPart().forEach(status -> {

--- a/sample-java/src/main/java/social/bigbone/sample/GetRawJson.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetRawJson.java
@@ -1,6 +1,7 @@
 package social.bigbone.sample;
 
 import social.bigbone.MastodonClient;
+import social.bigbone.api.Range;
 import social.bigbone.api.exception.BigboneRequestException;
 import social.bigbone.api.method.Public;
 
@@ -14,7 +15,7 @@ public class GetRawJson {
             final String credentialFilePath = args[1];
             final MastodonClient client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath, false);
             final Public publicMethod = new Public(client);
-            publicMethod.getLocalPublic().doOnJson(System.out::println).execute();
+            publicMethod.getPublic(new Range(), Public.StatusOrigin.LOCAL).doOnJson(System.out::println).execute();
         } catch (IOException | BigboneRequestException e) {
             e.printStackTrace();
         }

--- a/sample-java/src/main/java/social/bigbone/sample/GetTagTimelines.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetTagTimelines.java
@@ -15,7 +15,7 @@ public class GetTagTimelines {
         final Public publicMethod = new Public(client);
 
         try {
-            final Pageable<Status> statuses = publicMethod.getFederatedTag("mastodon", new Range()).execute();
+            final Pageable<Status> statuses = publicMethod.getTag("mastodon", new Range(), Public.StatusOrigin.LOCAL_AND_REMOTE).execute();
             statuses.getPart().forEach(status -> {
                 System.out.println("=============");
                 final Account account = status.getAccount();

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetRawJson.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetRawJson.kt
@@ -11,7 +11,7 @@ object GetRawJson {
         val client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath)
         runBlocking {
             val public = Public(client)
-            public.getLocalPublic().doOnJson {
+            public.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).doOnJson {
                 println(it)
             }.execute()
         }


### PR DESCRIPTION
Public.getPublic and Public.getTag now have a statusOrigin parameter that can be set to different values defined in Public.StatusOrigin to get either local or remote results, or a combination of both.

Removing previously used separate functions that did some of the above.

Documenting all of Public.kt with proper KDoc.

Closes #75.