### PR TITLE
change return value of MastodonLists.getLists

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/MastodonLists.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/MastodonLists.kt
@@ -10,17 +10,25 @@ import social.bigbone.api.exception.BigboneRequestException
 
 class MastodonLists(private val client: MastodonClient) {
 
-    // GET /api/v1/lists
-    fun getLists(): MastodonRequest<Pageable<MastodonList>> {
-        return client.getPageableMastodonRequest(
+    /**
+     * Gets all lists for the current user.
+     * @see <a href="https://docs.joinmastodon.org/methods/lists/#get">Mastodon API documentation: methods/lists/#get</a>
+     */
+    fun getLists(): MastodonRequest<List<MastodonList>> {
+        return client.getMastodonRequestForList(
             endpoint = "api/v1/lists",
             method = MastodonClient.Method.GET
         )
     }
 
-    // GET /api/v1/timelines/list/:list_id
+    /**
+     * Gets a list timeline of statuses for the given list.
+     * @param listID ID of the list for which a timeline should be returned
+     * @param range restrict result to a specific range
+     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#list">Mastodon API documentation: methods/timelines/#list</a>
+     */
     @Throws(BigboneRequestException::class)
-    fun getListTimeLine(listID: String, range: Range = Range()): MastodonRequest<Pageable<Status>> {
+    fun getListTimeline(listID: String, range: Range = Range()): MastodonRequest<Pageable<Status>> {
         return client.getPageableMastodonRequest(
             endpoint = "api/v1/timelines/list/$listID",
             method = MastodonClient.Method.GET,


### PR DESCRIPTION
MastodonLists.getLists previously returned a Pageable although this was not supported by the Mastodon endpoint. It now returns a List instead.

Also documenting MastodonLists.kt with KDoc.

Closes #74.