### PR TITLE
move all timeline-returning functions to Timelines.kt

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxPublic.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxPublic.kt
@@ -2,14 +2,10 @@ package social.bigbone.rx
 
 import io.reactivex.rxjava3.core.Single
 import social.bigbone.MastodonClient
-import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Instance
 import social.bigbone.api.entity.Results
-import social.bigbone.api.entity.Status
 import social.bigbone.api.method.Public
 import social.bigbone.rx.extensions.onErrorIfNotDisposed
-import social.bigbone.rx.extensions.single
 
 class RxPublic(client: MastodonClient) {
     private val publicMethod = Public(client)
@@ -33,25 +29,6 @@ class RxPublic(client: MastodonClient) {
             } catch (e: Throwable) {
                 it.onError(e)
             }
-        }
-    }
-
-    fun getPublic(
-        range: Range = Range(),
-        statusOrigin: Public.StatusOrigin = Public.StatusOrigin.LOCAL_AND_REMOTE
-    ): Single<Pageable<Status>> {
-        return single {
-            publicMethod.getPublic(range, statusOrigin).execute()
-        }
-    }
-
-    fun getTag(
-        tag: String,
-        range: Range = Range(),
-        statusOrigin: Public.StatusOrigin = Public.StatusOrigin.LOCAL_AND_REMOTE
-    ): Single<Pageable<Status>> {
-        return single {
-            publicMethod.getTag(tag, range, statusOrigin).execute()
         }
     }
 }

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxTimelines.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxTimelines.kt
@@ -11,9 +11,28 @@ import social.bigbone.rx.extensions.single
 class RxTimelines(client: MastodonClient) {
     val timelines = Timelines(client)
 
-    fun getHome(range: Range = Range()): Single<Pageable<Status>> {
+    fun getHomeTimeline(range: Range = Range()): Single<Pageable<Status>> {
         return single {
-            timelines.getHome(range).execute()
+            timelines.getHomeTimeline(range).execute()
+        }
+    }
+
+    fun getPublicTimeline(
+        range: Range = Range(),
+        statusOrigin: Timelines.StatusOrigin = Timelines.StatusOrigin.LOCAL_AND_REMOTE
+    ): Single<Pageable<Status>> {
+        return single {
+            timelines.getPublicTimeline(range, statusOrigin).execute()
+        }
+    }
+
+    fun getTagTimeline(
+        tag: String,
+        range: Range = Range(),
+        statusOrigin: Timelines.StatusOrigin = Timelines.StatusOrigin.LOCAL_AND_REMOTE
+    ): Single<Pageable<Status>> {
+        return single {
+            timelines.getTagTimeline(tag, range, statusOrigin).execute()
         }
     }
 }

--- a/bigbone-rx/src/test/kotlin/social/bigbone/rx/RxTimelinesTest.kt
+++ b/bigbone-rx/src/test/kotlin/social/bigbone/rx/RxTimelinesTest.kt
@@ -1,16 +1,16 @@
 package social.bigbone.rx
 
 import org.junit.jupiter.api.Test
-import social.bigbone.api.method.Public
+import social.bigbone.api.method.Timelines
 import social.bigbone.rx.testtool.MockClient
 
 class RxTimelinesTest {
 
     @Test
-    fun getPublic() {
+    fun getPublicTimeline() {
         val client = MockClient.mock("public_timeline.json", "5", "40")
-        val publicMethod = RxPublic(client)
-        val subscriber = publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).test()
+        val timelines = RxTimelines(client)
+        val subscriber = timelines.getPublicTimeline(statusOrigin = Timelines.StatusOrigin.LOCAL).test()
         subscriber.assertNoErrors()
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/MastodonLists.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/MastodonLists.kt
@@ -2,11 +2,7 @@ package social.bigbone.api.method
 
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
-import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.MastodonList
-import social.bigbone.api.entity.Status
-import social.bigbone.api.exception.BigboneRequestException
 
 class MastodonLists(private val client: MastodonClient) {
 
@@ -18,21 +14,6 @@ class MastodonLists(private val client: MastodonClient) {
         return client.getMastodonRequestForList(
             endpoint = "api/v1/lists",
             method = MastodonClient.Method.GET
-        )
-    }
-
-    /**
-     * Gets a list timeline of statuses for the given list.
-     * @param listID ID of the list for which a timeline should be returned
-     * @param range restrict result to a specific range
-     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#list">Mastodon API documentation: methods/timelines/#list</a>
-     */
-    @Throws(BigboneRequestException::class)
-    fun getListTimeline(listID: String, range: Range = Range()): MastodonRequest<Pageable<Status>> {
-        return client.getPageableMastodonRequest(
-            endpoint = "api/v1/timelines/list/$listID",
-            method = MastodonClient.Method.GET,
-            parameters = range.toParameter()
         )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Public.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Public.kt
@@ -3,22 +3,10 @@ package social.bigbone.api.method
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameter
-import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Instance
 import social.bigbone.api.entity.Results
-import social.bigbone.api.entity.Status
 
 class Public(private val client: MastodonClient) {
-
-    /**
-     * Public timelines can consist of only local statuses, only remote (=federated) statuses, or a combination of both.
-     */
-    enum class StatusOrigin {
-        LOCAL,
-        REMOTE,
-        LOCAL_AND_REMOTE
-    }
 
     /**
      * Retrieve instance details.
@@ -46,58 +34,6 @@ class Public(private val client: MastodonClient) {
                 append("q", query)
                 if (resolve) {
                     append("resolve", true)
-                }
-            }
-        )
-    }
-
-    /**
-     * Get the public timeline of the configured instance. Defaults to a combination of local and remote statuses,
-     * but can be restricted to either.
-     * @param range restrict result to a specific range
-     * @param statusOrigin optionally restrict result to either local or remote (=federated) statuses; defaults to all
-     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#public">Mastodon API documentation: methods/timelines/#public</a>
-     */
-    @JvmOverloads
-    fun getPublic(
-        range: Range = Range(),
-        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE
-    ): MastodonRequest<Pageable<Status>> {
-        return client.getPageableMastodonRequest(
-            endpoint = "api/v1/timelines/public",
-            method = MastodonClient.Method.GET,
-            parameters = range.toParameter().apply {
-                when (statusOrigin) {
-                    StatusOrigin.LOCAL -> append("local", true)
-                    StatusOrigin.REMOTE -> append("remote", true)
-                    else -> { /* append neither, combined results will be shown */ }
-                }
-            }
-        )
-    }
-
-    /**
-     * Get the public timeline for a specific hashtag of the configured instance.
-     * Defaults to a combination of local and remote (=federated) statuses, but can be restricted to either.
-     * @param tag the hashtag for which a timeline should be returned
-     * @param range restrict result to a specific range
-     * @param statusOrigin optionally restrict result to either local or remote statuses; defaults to all
-     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#tag">Mastodon API documentation: methods/timelines/#tag</a>
-     */
-    @JvmOverloads
-    fun getTag(
-        tag: String,
-        range: Range = Range(),
-        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE
-    ): MastodonRequest<Pageable<Status>> {
-        return client.getPageableMastodonRequest(
-            endpoint = "api/v1/timelines/tag/$tag",
-            method = MastodonClient.Method.GET,
-            parameters = range.toParameter().apply {
-                when (statusOrigin) {
-                    StatusOrigin.LOCAL -> append("local", true)
-                    StatusOrigin.REMOTE -> append("remote", true)
-                    else -> { /* append neither, combined results will be shown */ }
                 }
             }
         )

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Timelines.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Timelines.kt
@@ -11,14 +11,94 @@ import social.bigbone.api.exception.BigboneRequestException
  * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#timelines
  */
 class Timelines(private val client: MastodonClient) {
-    //  GET /api/v1/timelines/home
+    /**
+     * Public timelines can consist of only local statuses, only remote (=federated) statuses, or a combination of both.
+     */
+    enum class StatusOrigin {
+        LOCAL,
+        REMOTE,
+        LOCAL_AND_REMOTE
+    }
+
+    /**
+     * Gets the home timeline of statuses.
+     * @param range restrict result to a specific range
+     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#home">Mastodon API documentation: methods/timelines/#home</a>
+     */
     @JvmOverloads
     @Throws(BigboneRequestException::class)
-    fun getHome(range: Range = Range()): MastodonRequest<Pageable<Status>> {
+    fun getHomeTimeline(range: Range = Range()): MastodonRequest<Pageable<Status>> {
         return client.getPageableMastodonRequest(
             endpoint = "api/v1/timelines/home",
             method = MastodonClient.Method.GET,
             parameters = range.toParameter()
+        )
+    }
+
+    /**
+     * Gets a list timeline of statuses for the given list.
+     * @param listID ID of the list for which a timeline should be returned
+     * @param range restrict result to a specific range
+     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#list">Mastodon API documentation: methods/timelines/#list</a>
+     */
+    @Throws(BigboneRequestException::class)
+    fun getListTimeline(listID: String, range: Range = Range()): MastodonRequest<Pageable<Status>> {
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/list/$listID",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter()
+        )
+    }
+
+    /**
+     * Get the public timeline of the configured instance. Defaults to a combination of local and remote statuses,
+     * but can be restricted to either.
+     * @param range restrict result to a specific range
+     * @param statusOrigin optionally restrict result to either local or remote (=federated) statuses; defaults to all
+     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#public">Mastodon API documentation: methods/timelines/#public</a>
+     */
+    @JvmOverloads
+    fun getPublicTimeline(
+        range: Range = Range(),
+        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE
+    ): MastodonRequest<Pageable<Status>> {
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/public",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter().apply {
+                when (statusOrigin) {
+                    StatusOrigin.LOCAL -> append("local", true)
+                    StatusOrigin.REMOTE -> append("remote", true)
+                    else -> { /* append neither, combined results will be shown */ }
+                }
+            }
+        )
+    }
+
+    /**
+     * Get the public timeline for a specific hashtag of the configured instance.
+     * Defaults to a combination of local and remote (=federated) statuses, but can be restricted to either.
+     * @param tag the hashtag for which a timeline should be returned
+     * @param range restrict result to a specific range
+     * @param statusOrigin optionally restrict result to either local or remote statuses; defaults to all
+     * @see <a href="https://docs.joinmastodon.org/methods/timelines/#tag">Mastodon API documentation: methods/timelines/#tag</a>
+     */
+    @JvmOverloads
+    fun getTagTimeline(
+        tag: String,
+        range: Range = Range(),
+        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE
+    ): MastodonRequest<Pageable<Status>> {
+        return client.getPageableMastodonRequest(
+            endpoint = "api/v1/timelines/tag/$tag",
+            method = MastodonClient.Method.GET,
+            parameters = range.toParameter().apply {
+                when (statusOrigin) {
+                    StatusOrigin.LOCAL -> append("local", true)
+                    StatusOrigin.REMOTE -> append("remote", true)
+                    else -> { /* append neither, combined results will be shown */ }
+                }
+            }
         )
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/PublicTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/PublicTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import social.bigbone.api.exception.BigboneRequestException
 import social.bigbone.testtool.MockClient
 import social.bigbone.testtool.TestUtil
-import java.util.concurrent.atomic.AtomicInteger
 
 class PublicTest {
     @Test
@@ -79,59 +78,6 @@ class PublicTest {
             val client = MockClient.ioException()
             val publicMethod = Public(client)
             publicMethod.getSearch("test").execute()
-        }
-    }
-
-    @Test
-    fun getLocalPublic() {
-        val client = MockClient.mock("public_timeline.json", maxId = "3", sinceId = "1")
-        val publicMethod = Public(client)
-        val statuses = publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).execute()
-        statuses.part.size shouldBeEqualTo 20
-        statuses.link?.let {
-            it.nextPath shouldBeEqualTo "<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&max_id=3>"
-            it.maxId shouldBeEqualTo "3"
-            it.prevPath shouldBeEqualTo "<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&since_id=1>"
-            it.sinceId shouldBeEqualTo "1"
-        }
-    }
-
-    @Test
-    fun getLocalPublicWithJson() {
-        val atomicInt = AtomicInteger(0)
-        val client = MockClient.mock("public_timeline.json", maxId = "3", sinceId = "1")
-        val publicMethod = Public(client)
-        publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL)
-            .doOnJson {
-                atomicInt.incrementAndGet()
-            }
-            .execute()
-        atomicInt.get() shouldBeEqualTo 20
-    }
-
-    @Test
-    fun getLocalPublicWithException() {
-        Assertions.assertThrows(BigboneRequestException::class.java) {
-            val client = MockClient.ioException()
-            val publicMethod = Public(client)
-            publicMethod.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).execute()
-        }
-    }
-
-    @Test
-    fun getLocalTag() {
-        val client = MockClient.mock("tag.json", maxId = "3", sinceId = "1")
-        val publicMethod = Public(client)
-        val statuses = publicMethod.getTag(tag = "mastodon", statusOrigin = Public.StatusOrigin.LOCAL).execute()
-        statuses.part.size shouldBeEqualTo 20
-    }
-
-    @Test
-    fun getLocalTagWithException() {
-        Assertions.assertThrows(BigboneRequestException::class.java) {
-            val client = MockClient.ioException()
-            val publicMethod = Public(client)
-            publicMethod.getTag(tag = "mastodon", statusOrigin = Public.StatusOrigin.LOCAL).execute()
         }
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/TimelinesTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/TimelinesTest.kt
@@ -5,24 +5,78 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.api.exception.BigboneRequestException
 import social.bigbone.testtool.MockClient
+import java.util.concurrent.atomic.AtomicInteger
 
 class TimelinesTest {
 
     @Test
-    fun getHome() {
+    fun getHomeTimeline() {
         val client = MockClient.mock("timelines.json")
         val timelines = Timelines(client)
-        val pageable = timelines.getHome().execute()
+        val pageable = timelines.getHomeTimeline().execute()
         val status = pageable.part.first()
         status.id shouldBeEqualTo "11111"
     }
 
     @Test
-    fun homeWithException() {
+    fun getHomeTimelineWithException() {
         Assertions.assertThrows(BigboneRequestException::class.java) {
             val client = MockClient.ioException()
             val timelines = Timelines(client)
-            timelines.getHome().execute()
+            timelines.getHomeTimeline().execute()
+        }
+    }
+
+    @Test
+    fun getLocalPublicTimeline() {
+        val client = MockClient.mock("public_timeline.json", maxId = "3", sinceId = "1")
+        val timelines = Timelines(client)
+        val statuses = timelines.getPublicTimeline(statusOrigin = Timelines.StatusOrigin.LOCAL).execute()
+        statuses.part.size shouldBeEqualTo 20
+        statuses.link?.let {
+            it.nextPath shouldBeEqualTo "<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&max_id=3>"
+            it.maxId shouldBeEqualTo "3"
+            it.prevPath shouldBeEqualTo "<https://mstdn.jp/api/v1/timelines/public?limit=20&local=true&since_id=1>"
+            it.sinceId shouldBeEqualTo "1"
+        }
+    }
+
+    @Test
+    fun getLocalPublicTimelineWithJson() {
+        val atomicInt = AtomicInteger(0)
+        val client = MockClient.mock("public_timeline.json", maxId = "3", sinceId = "1")
+        val timelines = Timelines(client)
+        timelines.getPublicTimeline(statusOrigin = Timelines.StatusOrigin.LOCAL)
+            .doOnJson {
+                atomicInt.incrementAndGet()
+            }
+            .execute()
+        atomicInt.get() shouldBeEqualTo 20
+    }
+
+    @Test
+    fun getLocalPublicTimelineWithException() {
+        Assertions.assertThrows(BigboneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val timelines = Timelines(client)
+            timelines.getPublicTimeline(statusOrigin = Timelines.StatusOrigin.LOCAL).execute()
+        }
+    }
+
+    @Test
+    fun getLocalTagTimeline() {
+        val client = MockClient.mock("tag.json", maxId = "3", sinceId = "1")
+        val timelines = Timelines(client)
+        val statuses = timelines.getTagTimeline(tag = "mastodon", statusOrigin = Timelines.StatusOrigin.LOCAL).execute()
+        statuses.part.size shouldBeEqualTo 20
+    }
+
+    @Test
+    fun getLocalTagTimelineWithException() {
+        Assertions.assertThrows(BigboneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val timelines = Timelines(client)
+            timelines.getTagTimeline(tag = "mastodon", statusOrigin = Timelines.StatusOrigin.LOCAL).execute()
         }
     }
 

--- a/sample-java/src/main/java/social/bigbone/sample/GetPublicTimelines.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetPublicTimelines.java
@@ -6,16 +6,16 @@ import social.bigbone.api.Range;
 import social.bigbone.api.entity.Account;
 import social.bigbone.api.entity.Status;
 import social.bigbone.api.exception.BigboneRequestException;
-import social.bigbone.api.method.Public;
+import social.bigbone.api.method.Timelines;
 
 @SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.SystemPrintln"})
 public class GetPublicTimelines {
     public static void main(final String[] args) {
         final MastodonClient client = new MastodonClient.Builder("mstdn.jp").build();
-        final Public publicMethod = new Public(client);
+        final Timelines timelines = new Timelines(client);
 
         try {
-            final Pageable<Status> statuses = publicMethod.getPublic(new Range(), Public.StatusOrigin.LOCAL)
+            final Pageable<Status> statuses = timelines.getPublicTimeline(new Range(), Timelines.StatusOrigin.LOCAL)
                     .doOnJson(System.out::println)
                     .execute();
             statuses.getPart().forEach(status -> {

--- a/sample-java/src/main/java/social/bigbone/sample/GetRawJson.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetRawJson.java
@@ -3,7 +3,7 @@ package social.bigbone.sample;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Range;
 import social.bigbone.api.exception.BigboneRequestException;
-import social.bigbone.api.method.Public;
+import social.bigbone.api.method.Timelines;
 
 import java.io.IOException;
 
@@ -14,8 +14,8 @@ public class GetRawJson {
             final String instanceName = args[0];
             final String credentialFilePath = args[1];
             final MastodonClient client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath, false);
-            final Public publicMethod = new Public(client);
-            publicMethod.getPublic(new Range(), Public.StatusOrigin.LOCAL).doOnJson(System.out::println).execute();
+            final Timelines timelines = new Timelines(client);
+            timelines.getPublicTimeline(new Range(), Timelines.StatusOrigin.LOCAL).doOnJson(System.out::println).execute();
         } catch (IOException | BigboneRequestException e) {
             e.printStackTrace();
         }

--- a/sample-java/src/main/java/social/bigbone/sample/GetTagTimelines.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetTagTimelines.java
@@ -5,17 +5,17 @@ import social.bigbone.api.Pageable;
 import social.bigbone.api.Range;
 import social.bigbone.api.entity.Account;
 import social.bigbone.api.entity.Status;
-import social.bigbone.api.method.Public;
 import social.bigbone.api.exception.BigboneRequestException;
+import social.bigbone.api.method.Timelines;
 
 @SuppressWarnings({"PMD.SystemPrintln", "PMD.AvoidPrintStackTrace"})
 public class GetTagTimelines {
     public static void main(final String[] args) {
         final MastodonClient client = new MastodonClient.Builder("mstdn.jp").build();
-        final Public publicMethod = new Public(client);
+        final Timelines timelines = new Timelines(client);
 
         try {
-            final Pageable<Status> statuses = publicMethod.getTag("mastodon", new Range(), Public.StatusOrigin.LOCAL_AND_REMOTE).execute();
+            final Pageable<Status> statuses = timelines.getTagTimeline("mastodon", new Range(), Timelines.StatusOrigin.LOCAL_AND_REMOTE).execute();
             statuses.getPart().forEach(status -> {
                 System.out.println("=============");
                 final Account account = status.getAccount();

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetRawJson.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetRawJson.kt
@@ -1,7 +1,7 @@
 package social.bigbone.sample
 
 import kotlinx.coroutines.runBlocking
-import social.bigbone.api.method.Public
+import social.bigbone.api.method.Timelines
 
 object GetRawJson {
     @JvmStatic
@@ -10,8 +10,8 @@ object GetRawJson {
         val credentialFilePath = args[1]
         val client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath)
         runBlocking {
-            val public = Public(client)
-            public.getPublic(statusOrigin = Public.StatusOrigin.LOCAL).doOnJson {
+            val timelines = Timelines(client)
+            timelines.getPublicTimeline(statusOrigin = Timelines.StatusOrigin.LOCAL).doOnJson {
                 println(it)
             }.execute()
         }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Kotlindon.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Kotlindon.kt
@@ -16,17 +16,17 @@ object Kotlindon {
         val instanceName = args[0]
         val credentialFilePath = args[1]
         val client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath)
-        listenHome(client)
+        listenHomeTimeline(client)
     }
 
-    fun listenHome(client: MastodonClient) {
+    fun listenHomeTimeline(client: MastodonClient) {
         runBlocking {
             val timelines = Timelines(client)
             var pageable: Pageable<Status>? = null
             while (true) {
                 val result = pageable?.let {
-                    timelines.getHome(it.prevRange(limit = 5)).execute()
-                } ?: timelines.getHome(Range(limit = 5)).execute()
+                    timelines.getHomeTimeline(it.prevRange(limit = 5)).execute()
+                } ?: timelines.getHomeTimeline(Range(limit = 5)).execute()
 
                 result.part.sortedBy { it.createdAt }.forEach {
                     println(it.account?.displayName)


### PR DESCRIPTION
- renaming all functions to get***Timeline to be consistent
- moving around related functions in Rx and tests

Closes #81