### PR TITLE
remove links to https://github.com/tootsuite

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
@@ -1,8 +1,5 @@
 package social.bigbone.api
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/OAuth-details.md
- */
 class Scope
 @JvmOverloads
 constructor(private vararg val scopes: Name = arrayOf(Name.ALL)) {

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Application.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Application.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#application
- */
 class Application(
     @SerializedName("name")
     val name: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Attachment.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Attachment.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#attachment
- */
 class Attachment(
     @SerializedName("id") val id: String = "0",
     @SerializedName("type") val type: String = Type.Image.value,

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Card.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Card.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#card
- */
 class Card(
     @SerializedName("url")
     val url: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Context.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Context.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#context
- */
 class Context(
     @SerializedName("ancestors")
     val ancestors: List<Status> = emptyList(),

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Emoji.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Emoji.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#emoji
- */
 class Emoji(
     @SerializedName("shortcode")
     val shortcode: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Error.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Error.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#error
- */
 class Error(
     @SerializedName("error")
     val error: String = ""

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Instance.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Instance.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#instance
- */
 data class Instance(
     @SerializedName("uri")
     val uri: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/InstanceStats.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/InstanceStats.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#instance
- */
 data class InstanceStats(
     @SerializedName("user_count")
     val userCount: Int = 0,

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/InstanceUrls.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/InstanceUrls.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#instance
- */
 data class InstanceUrls(
     @SerializedName("streaming_api")
     val streamingApi: String = ""

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Mention.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Mention.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#mention
- */
 class Mention(
     @SerializedName("url")
     val url: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Notification.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Notification.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#notification
- */
 class Notification(
     @SerializedName("id")
     val id: String = "0", // The notification ID

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Relationship.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Relationship.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#relationship
- */
 class Relationship(
     @SerializedName("id")
     val id: String = "0",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Report.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Report.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#reports
- */
 class Report(
     @SerializedName("id")
     val id: String = "0", // The ID of the report

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Results.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Results.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#results
- */
 class Results(
     @SerializedName("accounts")
     val accounts: List<Account> = emptyList(), // An array of matched Accounts

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#status
- */
 class Status(
     @SerializedName("id") val id: String = "0",
     @SerializedName("uri") val uri: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Tag.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Tag.kt
@@ -2,9 +2,6 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#tag
- */
 class Tag(
     @SerializedName("name")
     val name: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Accounts.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Accounts.kt
@@ -9,9 +9,6 @@ import social.bigbone.api.entity.Account
 import social.bigbone.api.entity.Relationship
 import social.bigbone.api.entity.Status
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#accounts
- */
 class Accounts(private val client: MastodonClient) {
     // GET /api/v1/accounts/:id
     fun getAccount(accountId: String): MastodonRequest<Account> {

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Blocks.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Blocks.kt
@@ -6,9 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#blocks
- */
 class Blocks(private val client: MastodonClient) {
 
     //  GET /api/v1/blocks

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Favourites.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Favourites.kt
@@ -6,9 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Status
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#favourites
- */
 class Favourites(private val client: MastodonClient) {
 
     //  GET /api/v1/favourites

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/FollowRequests.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/FollowRequests.kt
@@ -7,9 +7,6 @@ import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.api.exception.BigboneRequestException
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#follow-requests
- */
 class FollowRequests(private val client: MastodonClient) {
     // GET /api/v1/follow_requests
     @JvmOverloads

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
@@ -5,9 +5,6 @@ import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.api.entity.Attachment
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#media
- */
 class Media(private val client: MastodonClient) {
     //  POST /api/v1/media
     fun postMedia(file: MultipartBody.Part): MastodonRequest<Attachment> {

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Mutes.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Mutes.kt
@@ -6,9 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#mutes
- */
 class Mutes(private val client: MastodonClient) {
     // GET /api/v1/mutes
     @JvmOverloads

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Notifications.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Notifications.kt
@@ -7,9 +7,6 @@ import social.bigbone.api.Range
 import social.bigbone.api.entity.Notification
 import social.bigbone.api.exception.BigboneRequestException
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#notifications
- */
 class Notifications(private val client: MastodonClient) {
     // GET /api/v1/notifications
     @JvmOverloads

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Reports.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Reports.kt
@@ -8,9 +8,6 @@ import social.bigbone.api.Range
 import social.bigbone.api.entity.Report
 import social.bigbone.api.exception.BigboneRequestException
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#reports
- */
 class Reports(private val client: MastodonClient) {
     // GET /api/v1/reports
     @JvmOverloads

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Statuses.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Statuses.kt
@@ -11,9 +11,6 @@ import social.bigbone.api.entity.Context
 import social.bigbone.api.entity.Status
 import social.bigbone.api.exception.BigboneRequestException
 
-/**
- * See more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#statuses
- */
 class Statuses(private val client: MastodonClient) {
 
     //  GET /api/v1/statuses/:id

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Timelines.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Timelines.kt
@@ -7,9 +7,6 @@ import social.bigbone.api.Range
 import social.bigbone.api.entity.Status
 import social.bigbone.api.exception.BigboneRequestException
 
-/**
- * see more https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#timelines
- */
 class Timelines(private val client: MastodonClient) {
     /**
      * Public timelines can consist of only local statuses, only remote (=federated) statuses, or a combination of both.


### PR DESCRIPTION
The repository https://github.com/tootsuite no longer exists, and link structure in current Mastodon API documentation has changed so that remaining links in comments are not useful.