### PR TITLE
Fixed broken search

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Results.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Results.kt
@@ -4,11 +4,11 @@ import com.google.gson.annotations.SerializedName
 
 class Results(
     @SerializedName("accounts")
-    val accounts: List<Account> = emptyList(), // An array of matched Accounts
+    val accounts: List<Account> = emptyList(),
 
     @SerializedName("statuses")
-    val statuses: List<Status> = emptyList(), // An array of matched Statuses
+    val statuses: List<Status> = emptyList(),
 
     @SerializedName("hashtags")
-    val hashtags: List<String> = emptyList() // An array of matched hashtags, as strings
+    val hashtags: List<Tag> = emptyList()
 )

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Public.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Public.kt
@@ -28,7 +28,7 @@ class Public(private val client: MastodonClient) {
     @JvmOverloads
     fun getSearch(query: String, resolve: Boolean = false): MastodonRequest<Results> {
         return client.getMastodonRequest(
-            endpoint = "api/v1/search",
+            endpoint = "api/v2/search",
             method = MastodonClient.Method.GET,
             parameters = Parameter().apply {
                 append("q", query)

--- a/bigbone/src/test/assets/search.json
+++ b/bigbone/src/test/assets/search.json
@@ -103,12 +103,31 @@
       "header_static": "https://media.mstdn.jp/images/accounts/headers/000/114/430/original/missing.png?1492647430"
     }
   ],
-  "statuses": [],
+  "statuses": [
+    {
+      "id": "103085519055545958",
+      "created_at": "2019-11-05T13:23:09.000Z",
+      "spoiler_text": "Cat rules",
+      "content": "<p>cats<br>cats never change</p>"
+    },
+    {
+      "id": "101068121469614510",
+      "created_at": "2018-11-14T06:31:48.000Z",
+      "spoiler_text": "Cats",
+      "content": "<p>Cats are inherently good at self-care. </p><p><a href=\"https://mspsocial.net/tags/cats\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>cats</span></a></p>"
+    }
+  ],
   "hashtags": [
-    "testestest",
-    "testset",
-    "test918492",
-    "test7144",
-    "test"
+    {
+      "name": "catsofmastodon",
+      "url": "https://mastodon.social/tags/catsofmastodon",
+      "history": [
+        {
+          "day": "1574553600",
+          "uses": "6",
+          "accounts": "5"
+        }
+      ]
+    }
   ]
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/PublicTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/PublicTest.kt
@@ -66,10 +66,9 @@ class PublicTest {
 
         val publicMethod = Public(client)
         val result = publicMethod.getSearch("test").execute()
-        result.statuses.size shouldBeEqualTo 0
         result.accounts.size shouldBeEqualTo 6
-        result.hashtags.size shouldBeEqualTo 5
-        result.hashtags.size shouldBeEqualTo 5
+        result.statuses.size shouldBeEqualTo 2
+        result.hashtags.size shouldBeEqualTo 1
     }
 
     @Test

--- a/sample-java/src/main/java/social/bigbone/sample/Search.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Search.java
@@ -1,0 +1,32 @@
+package social.bigbone.sample;
+
+import social.bigbone.MastodonClient;
+import social.bigbone.api.entity.Results;
+import social.bigbone.api.exception.BigboneRequestException;
+import social.bigbone.api.method.Public;
+
+import java.io.IOException;
+
+@SuppressWarnings({"PMD.SystemPrintln", "PMD.AvoidPrintStackTrace"})
+public class Search {
+    public static void main(final String[] args) {
+        try {
+            final String instanceName = args[0];
+            final String credentialFilePath = args[1];
+            final MastodonClient client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath, false);
+            final Public publicMethod = new Public(client);
+            final Results searchResult = publicMethod.getSearch("bigbone").execute();
+            searchResult.getAccounts().forEach(account -> {
+                System.out.println(account.getDisplayName());
+            });
+            searchResult.getStatuses().forEach(status -> {
+                System.out.println(status.getContent());
+            });
+            searchResult.getHashtags().forEach(hashtag -> {
+                System.out.println(hashtag.getName());
+            });
+        } catch (IOException | BigboneRequestException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Search.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Search.kt
@@ -1,0 +1,26 @@
+package social.bigbone.sample
+
+import kotlinx.coroutines.runBlocking
+import social.bigbone.api.method.Public
+
+object Search {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val instanceName = args[0]
+        val credentialFilePath = args[1]
+        val client = Authenticator.appRegistrationIfNeeded(instanceName, credentialFilePath)
+        runBlocking {
+            val publicMethod = Public(client)
+            val searchResult = publicMethod.getSearch("bigbone").execute()
+            searchResult.accounts.forEach {
+                println(it.displayName)
+            }
+            searchResult.statuses.forEach {
+                println(it.content)
+            }
+            searchResult.hashtags.forEach {
+                println(it.name)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Existing search implementation was targeting the /api/v1/search endpoint which was removed from Mastodon servers entirely. With this commit, search is revived by implementing the v2 endpoint that is offered on Mastodon servers nowadays. Basic search functionality works. It finds statuses, people and hashtags based on a search query.

Other filter criteria is still missing and will be added later.