### PR TITLE
don't expose okhttp3.MultipartBody.Part via Media.postMedia()

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxMedia.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxMedia.kt
@@ -1,18 +1,18 @@
 package social.bigbone.rx
 
 import io.reactivex.rxjava3.core.Single
-import okhttp3.MultipartBody
 import social.bigbone.MastodonClient
 import social.bigbone.api.entity.Attachment
 import social.bigbone.api.method.Media
+import java.io.File
 
 class RxMedia(client: MastodonClient) {
     val media = Media(client)
 
-    fun postMedia(part: MultipartBody.Part): Single<Attachment> {
+    fun postMedia(file: File, mediaType: String): Single<Attachment> {
         return Single.create {
             try {
-                val result = media.postMedia(part)
+                val result = media.postMedia(file, mediaType)
                 it.onSuccess(result.execute())
             } catch (e: Throwable) {
                 it.onError(e)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
@@ -6,6 +6,7 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.api.entity.Attachment
+import java.io.File
 
 class Media(private val client: MastodonClient) {
     /**
@@ -14,7 +15,7 @@ class Media(private val client: MastodonClient) {
      * @param mediaType media type of the file as a string, e.g. "image/png"
      * @see <a href="https://docs.joinmastodon.org/methods/media/#v1">Mastodon API documentation: methods/media/#v1</a>
      */
-    fun postMedia(file: java.io.File, mediaType: String): MastodonRequest<Attachment> {
+    fun postMedia(file: File, mediaType: String): MastodonRequest<Attachment> {
         val body = file.asRequestBody(mediaType.toMediaTypeOrNull())
         val part = MultipartBody.Part.createFormData("file", file.name, body)
         val requestBody = MultipartBody.Builder()

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/Media.kt
@@ -1,16 +1,25 @@
 package social.bigbone.api.method
 
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.api.entity.Attachment
 
 class Media(private val client: MastodonClient) {
-    //  POST /api/v1/media
-    fun postMedia(file: MultipartBody.Part): MastodonRequest<Attachment> {
+    /**
+     * Creates an attachment to be used with a new status.
+     * @param file the file that should be uploaded
+     * @param mediaType media type of the file as a string, e.g. "image/png"
+     * @see <a href="https://docs.joinmastodon.org/methods/media/#v1">Mastodon API documentation: methods/media/#v1</a>
+     */
+    fun postMedia(file: java.io.File, mediaType: String): MastodonRequest<Attachment> {
+        val body = file.asRequestBody(mediaType.toMediaTypeOrNull())
+        val part = MultipartBody.Part.createFormData("file", file.name, body)
         val requestBody = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addPart(file)
+            .addPart(part)
             .build()
         return MastodonRequest<Attachment>(
             {

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/MediaTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/MediaTest.kt
@@ -1,20 +1,21 @@
 package social.bigbone.api.method
 
-import okhttp3.MultipartBody
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.api.exception.BigboneRequestException
-import social.bigbone.extension.emptyRequestBody
 import social.bigbone.testtool.MockClient
+import java.io.File
 
 class MediaTest {
     @Test
     fun postMedia() {
         val client = MockClient.mock("attachment.json")
         val media = Media(client)
-        val attachment = media.postMedia(MultipartBody.Part.create(emptyRequestBody())).execute()
+        val file = File("foo.bar")
+        val mediaType = "image/foo"
+        val attachment = media.postMedia(file, mediaType).execute()
         attachment.id shouldBeEqualTo "10"
         attachment.type shouldBeEqualTo "video"
         attachment.url shouldBeEqualTo "youtube"
@@ -28,7 +29,9 @@ class MediaTest {
         Assertions.assertThrows(BigboneRequestException::class.java) {
             val client = MockClient.ioException()
             val media = Media(client)
-            media.postMedia(MultipartBody.Part.create(emptyRequestBody())).execute()
+            val file = File("foo.bar")
+            val mediaType = "image/foo"
+            media.postMedia(file, mediaType).execute()
         }
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/MediaUpload.java
+++ b/sample-java/src/main/java/social/bigbone/sample/MediaUpload.java
@@ -1,8 +1,5 @@
 package social.bigbone.sample;
 
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.RequestBody;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.entity.Attachment;
 import social.bigbone.api.entity.Status.Visibility;
@@ -30,9 +27,7 @@ public class MediaUpload {
 
             // Upload image to Mastodon
             final Media media = new Media(client);
-            final RequestBody requestBody = RequestBody.create(uploadFile, MediaType.parse("image/jpg"));
-            final MultipartBody.Part pFile = MultipartBody.Part.createFormData("file", uploadFile.getName(), requestBody);
-            final Attachment uploadedFile = media.postMedia(pFile).execute();
+            final Attachment uploadedFile = media.postMedia(uploadFile, "image/jpg").execute();
             final String mediaId = uploadedFile.getId();
 
             // Post status with media attached


### PR DESCRIPTION
Changes Media.postMedia() to accept a File and a media type String as parameters, then builds the necessary okhttp3.MultipartBody.Part itself instead of exposing this.

A more extensive Builder was suggested in #62, but I think that would need to live elsewhere, not directly in one of our method classes.