### PR TITLE
stop Gson exposure by making MastodonClient.getSerializer internal

### DIFF
--- a/bigbone-rx/src/test/kotlin/social/bigbone/rx/testtool/MockClient.kt
+++ b/bigbone-rx/src/test/kotlin/social/bigbone/rx/testtool/MockClient.kt
@@ -37,7 +37,10 @@ object MockClient {
             }
             .build()
         every { client.get(ofType<String>(), any()) } returns response
-        every { client.getSerializer() } returns Gson()
+
+        // mocking function that is internal in MastodonClient
+        every { client["getSerializer"]() } returns Gson()
+
         return client
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -30,7 +30,8 @@ private constructor(
         PATCH
     }
 
-    open fun getSerializer() = gson
+    @PublishedApi
+    internal fun getSerializer() = gson
 
     open fun getInstanceName() = instanceName
 

--- a/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
@@ -1,5 +1,6 @@
 package social.bigbone.sample;
 
+import com.google.gson.Gson;
 import social.bigbone.MastodonClient;
 import social.bigbone.MastodonRequest;
 import social.bigbone.Parameter;
@@ -95,7 +96,7 @@ final class Authenticator {
                 .append("grant_type", "password");
         return new MastodonRequest<>(
                 () -> client.post("oauth/token", parameters),
-                s -> client.getSerializer().fromJson(s, AccessToken.class)
+                s -> new Gson().fromJson(s, AccessToken.class)
         );
     }
 }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
@@ -1,5 +1,6 @@
 package social.bigbone.sample
 
+import com.google.gson.Gson
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameter
@@ -109,7 +110,7 @@ object Authenticator {
                 client.post("oauth/token", parameters)
             },
             {
-                client.getSerializer().fromJson(it, AccessToken::class.java)
+                Gson().fromJson(it, AccessToken::class.java)
             }
         )
     }


### PR DESCRIPTION
This closes #51.

There are some weird things going on that I want to mention here:
- mocking an otherwise inaccessible function via dynamic call in the `MockClient` for bigbone-rx. This might be a sign of either a badly designed test, or other structural issues.
- creating separate Gson() instances directly in our samples. This should typically not be done, but those samples use undocumented functionality and need to be rewritten anyway.

Neither is really great, but we shouldn't keep `MastodonClient.getSerializer()` public only to keep tests and outdated samples working.

I also had to use `@PublishedApi` on the now internal function. That means that the function is ["technically exposed in bytecode" but not able to be called directly from outside the module](https://stackoverflow.com/questions/68211527/kotlin-what-is-the-point-of-publishedapi). I assume this is OK.