### PR TITLE
Dependency cleanup / maintenance

### DIFF
--- a/bigbone/build.gradle
+++ b/bigbone/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation libs.kotlin.jdk8
 
     testImplementation libs.junit.jupiter
-    testImplementation libs.okio
     testImplementation libs.kluent
     testImplementation libs.mockk
     testImplementation libs.mockk.dsl

--- a/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
@@ -7,9 +7,8 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.asResponseBody
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
-import okio.BufferedSource
 import social.bigbone.MastodonClient
 import java.net.SocketTimeoutException
 
@@ -52,20 +51,14 @@ object MockClient {
 
     fun ioException(): MastodonClient {
         val clientMock: MastodonClient = mockk()
-        val source: BufferedSource = mockk()
-        every { source.readString(any()) } throws SocketTimeoutException()
+        val responseBodyMock: ResponseBody = mockk()
+        every { responseBodyMock.toString() } throws SocketTimeoutException()
         val response: Response = Response.Builder()
             .code(200)
             .message("OK")
             .request(Request.Builder().url("https://test.com/").build())
             .protocol(Protocol.HTTP_1_1)
-            .body(
-                source
-                    .asResponseBody(
-                        "application/json; charset=utf-8".toMediaTypeOrNull(),
-                        1024
-                    )
-            )
+            .body(responseBodyMock)
             .build()
 
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
     alias(libs.plugins.dependency.analysis)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.versions)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,20 +3,20 @@
 bigbone = "2.0.0-SNAPSHOT"
 
 # 3rd party dependencies
-gson = "2.10"
-junit-jupiter = "5.9.1"
+gson = "2.10.1"
+junit-jupiter = "5.9.2"
 kluent = "1.72"
 kotlin = "1.7.21"
 kotlin-coroutines = "1.6.4"
 mockk = "1.13.3"
 okhttp = "4.10.0"
-okio = "3.2.0"
 rxjava = "3.1.5"
 
 # Gradle plugins
 jacoco = "0.8.8"
 dependency-analysis = "1.18.0"
 detekt = "1.22.0"
+versions = "0.44.0"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
@@ -26,7 +26,6 @@ kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", 
 kotlin-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-dsl = { module = "io.mockk:mockk-dsl", version.ref = "mockk" }
-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 rxjava = { module="io.reactivex.rxjava3:rxjava", version.ref="rxjava"}
@@ -36,3 +35,4 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }


### PR DESCRIPTION
Added Gradle versions plugin to allow easy checking for updated dependencies. Removed okio library, as it was used in a single place only (test scope). Updated dependencies to latest versions.