### PR TITLE
rename Attachment entity to MediaAttachment, following Mastodon API

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxMediaMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxMediaMethods.kt
@@ -2,14 +2,14 @@ package social.bigbone.rx
 
 import io.reactivex.rxjava3.core.Single
 import social.bigbone.MastodonClient
-import social.bigbone.api.entity.Attachment
+import social.bigbone.api.entity.MediaAttachment
 import social.bigbone.api.method.MediaMethods
 import java.io.File
 
 class RxMediaMethods(client: MastodonClient) {
     private val mediaMethods = MediaMethods(client)
 
-    fun uploadMedia(file: File, mediaType: String): Single<Attachment> {
+    fun uploadMedia(file: File, mediaType: String): Single<MediaAttachment> {
         return Single.create {
             try {
                 val result = mediaMethods.uploadMedia(file, mediaType)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/MediaAttachment.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/MediaAttachment.kt
@@ -2,7 +2,7 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-data class Attachment(
+data class MediaAttachment(
     @SerializedName("id")
     val id: String = "0",
 

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
@@ -58,7 +58,7 @@ data class Status(
     val visibility: String = Visibility.Public.value,
 
     @SerializedName("media_attachments")
-    val mediaAttachments: List<Attachment> = emptyList(),
+    val mediaAttachments: List<MediaAttachment> = emptyList(),
 
     @SerializedName("mentions")
     val mentions: List<Mention> = emptyList(),

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/MediaMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/MediaMethods.kt
@@ -5,7 +5,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
-import social.bigbone.api.entity.Attachment
+import social.bigbone.api.entity.MediaAttachment
 import java.io.File
 
 /**
@@ -19,19 +19,19 @@ class MediaMethods(private val client: MastodonClient) {
      * @param mediaType media type of the file as a string, e.g. "image/png"
      * @see <a href="https://docs.joinmastodon.org/methods/media/#v1">Mastodon API documentation: methods/media/#v1</a>
      */
-    fun uploadMedia(file: File, mediaType: String): MastodonRequest<Attachment> {
+    fun uploadMedia(file: File, mediaType: String): MastodonRequest<MediaAttachment> {
         val body = file.asRequestBody(mediaType.toMediaTypeOrNull())
         val part = MultipartBody.Part.createFormData("file", file.name, body)
         val requestBody = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addPart(part)
             .build()
-        return MastodonRequest<Attachment>(
+        return MastodonRequest<MediaAttachment>(
             {
                 client.postRequestBody("api/v1/media", requestBody)
             },
             {
-                client.getSerializer().fromJson(it, Attachment::class.java)
+                client.getSerializer().fromJson(it, MediaAttachment::class.java)
             }
         )
     }

--- a/bigbone/src/test/kotlin/social/bigbone/api/entity/MediaAttachmentTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/entity/MediaAttachmentTest.kt
@@ -6,16 +6,16 @@ import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.Test
 import social.bigbone.testtool.AssetsUtil
 
-class AttachmentTest {
+class MediaAttachmentTest {
     @Test
     fun deserialize() {
         val json = AssetsUtil.readFromAssets("attachment.json")
-        val status: Attachment = Gson().fromJson(json, Attachment::class.java)
+        val status: MediaAttachment = Gson().fromJson(json, MediaAttachment::class.java)
         status.id shouldBeEqualTo "10"
         status.url shouldBeEqualTo "youtube"
         status.remoteUrl shouldNotBe null
         status.previewUrl shouldBeEqualTo "preview"
         status.textUrl shouldNotBe null
-        status.type shouldBeEqualTo Attachment.Type.Video.value
+        status.type shouldBeEqualTo MediaAttachment.Type.Video.value
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/PostStatusWithMediaAttached.java
+++ b/sample-java/src/main/java/social/bigbone/sample/PostStatusWithMediaAttached.java
@@ -1,7 +1,7 @@
 package social.bigbone.sample;
 
 import social.bigbone.MastodonClient;
-import social.bigbone.api.entity.Attachment;
+import social.bigbone.api.entity.MediaAttachment;
 import social.bigbone.api.entity.Status.Visibility;
 import social.bigbone.api.exception.BigBoneRequestException;
 
@@ -24,7 +24,7 @@ public class PostStatusWithMediaAttached {
         final File uploadFile = new File(classLoader.getResource("castle.jpg").getFile());
 
         // Upload image to Mastodon
-        final Attachment uploadedFile = client.media().uploadMedia(uploadFile, "image/jpg").execute();
+        final MediaAttachment uploadedFile = client.media().uploadMedia(uploadFile, "image/jpg").execute();
         final String mediaId = uploadedFile.getId();
 
         // Post status with media attached


### PR DESCRIPTION
Closing #120.