### PR TITLE
remove method to get reports; allow multiple IDs when filing

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxReportMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxReportMethods.kt
@@ -2,29 +2,16 @@ package social.bigbone.rx
 
 import io.reactivex.rxjava3.core.Single
 import social.bigbone.MastodonClient
-import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Report
 import social.bigbone.api.method.ReportMethods
 
 class RxReportMethods(client: MastodonClient) {
     private val reportMethods = ReportMethods(client)
 
-    fun getReports(range: Range = Range()): Single<Pageable<Report>> {
+    fun fileReport(accountId: String, statusIds: List<String>, comment: String): Single<Report> {
         return Single.create {
             try {
-                val reports = reportMethods.getReports(range)
-                it.onSuccess(reports.execute())
-            } catch (e: Throwable) {
-                it.onError(e)
-            }
-        }
-    }
-
-    fun fileReport(accountId: String, statusId: String, comment: String): Single<Report> {
-        return Single.create {
-            try {
-                val report = reportMethods.fileReport(accountId, statusId, comment)
+                val report = reportMethods.fileReport(accountId, statusIds, comment)
                 it.onSuccess(report.execute())
             } catch (e: Throwable) {
                 it.onError(e)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/ReportMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/ReportMethods.kt
@@ -3,8 +3,6 @@ package social.bigbone.api.method
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameters
-import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Report
 import social.bigbone.api.exception.BigBoneRequestException
 
@@ -13,32 +11,21 @@ import social.bigbone.api.exception.BigBoneRequestException
  * @see <a href="https://docs.joinmastodon.org/methods/reports/">Mastodon reports API methods</a>
  */
 class ReportMethods(private val client: MastodonClient) {
-    // GET /api/v1/reports
-    @JvmOverloads
-    @Throws(BigBoneRequestException::class)
-    fun getReports(range: Range = Range()): MastodonRequest<Pageable<Report>> {
-        return client.getPageableMastodonRequest(
-            endpoint = "api/v1/reports",
-            method = MastodonClient.Method.GET,
-            parameters = range.toParameters()
-        )
-    }
-
     /**
      * File a report.
      * @param accountId The ID of the account to report
-     * @param statusId The ID of a status to report
+     * @param statusIds List of ID strings for statuses to be reported
      * @param comment The reason for the report. Default maximum of 1000 characters.
      * @see <a href="https://docs.joinmastodon.org/methods/reports/#post">Mastodon API documentation: methods/reports/#post</a>
      */
     @Throws(BigBoneRequestException::class)
-    fun fileReport(accountId: String, statusId: String, comment: String): MastodonRequest<Report> {
+    fun fileReport(accountId: String, statusIds: List<String>, comment: String): MastodonRequest<Report> {
         return client.getMastodonRequest(
             endpoint = "api/v1/reports",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("account_id", accountId)
-                append("status_ids", statusId)
+                append("status_ids", statusIds)
                 append("comment", comment)
             }
         )

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/ReportMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/ReportMethodsTest.kt
@@ -1,6 +1,5 @@
 package social.bigbone.api.method
 
-import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.api.exception.BigBoneRequestException
@@ -8,30 +7,12 @@ import social.bigbone.testtool.MockClient
 
 class ReportMethodsTest {
     @Test
-    fun getReports() {
-        val client = MockClient.mock("reports.json")
-        val reportMethods = ReportMethods(client)
-        val pageable = reportMethods.getReports().execute()
-        val report = pageable.part.first()
-        report.id shouldBeEqualTo "100"
-        report.actionTaken shouldBeEqualTo "test"
-    }
-
-    @Test
-    fun getReportsWithException() {
-        Assertions.assertThrows(BigBoneRequestException::class.java) {
-            val client = MockClient.ioException()
-            val reportMethods = ReportMethods(client)
-            reportMethods.getReports().execute()
-        }
-    }
-
-    @Test
     fun fileReportWithException() {
         Assertions.assertThrows(BigBoneRequestException::class.java) {
             val client = MockClient.ioException()
             val reportMethods = ReportMethods(client)
-            reportMethods.fileReport("10", "20", "test").execute()
+            val statusIds = listOf("12345", "67890")
+            reportMethods.fileReport("10", statusIds, "test").execute()
         }
     }
 }


### PR DESCRIPTION
According to https://docs.joinmastodon.org/methods/reports/, a method to get previously filed reports does not exist and needs to be removed. Filing a report allows more than one status ID to be attached, whereas we previously supported just one status ID.

Fixing both issues and related tests, closing #117.