### PR TITLE
add some missing members to Status entity

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
@@ -6,8 +6,8 @@ import social.bigbone.MastodonClient
 import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
-import social.bigbone.api.entity.Card
 import social.bigbone.api.entity.Context
+import social.bigbone.api.entity.PreviewCard
 import social.bigbone.api.entity.Status
 import social.bigbone.api.method.StatusMethods
 
@@ -36,7 +36,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
-    fun getCard(statusId: String): Single<Card> {
+    fun getCard(statusId: String): Single<PreviewCard> {
         return Single.create {
             try {
                 val context = statusMethods.getCard(statusId)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/PreviewCard.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/PreviewCard.kt
@@ -2,7 +2,7 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
-data class Card(
+data class PreviewCard(
     @SerializedName("url")
     val url: String = "",
 

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
@@ -2,78 +2,195 @@ package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents a status posted by an account.
+ * @see <a href="https://docs.joinmastodon.org/entities/Status/">Mastodon API Status</a>
+ */
 data class Status(
+    /**
+     * ID of the status in the database.
+     */
     @SerializedName("id")
     val id: String = "0",
 
+    /**
+     * URI of the status used for federation.
+     */
     @SerializedName("uri")
     val uri: String = "",
 
-    @SerializedName("url")
-    val url: String = "",
-
-    @SerializedName("account")
-    val account: Account? = null,
-
-    @SerializedName("in_reply_to_id")
-    val inReplyToId: String? = null,
-
-    @SerializedName("in_reply_to_account_id")
-    val inReplyToAccountId: String? = null,
-
-    @SerializedName("reblog")
-    val reblog: Status? = null,
-
-    @SerializedName("content")
-    val content: String = "",
-
+    /**
+     * The date when this status was created (ISO 8601 Datetime).
+     */
     @SerializedName("created_at")
     val createdAt: String = "",
 
-    @SerializedName("emojis")
-    val emojis: List<Emoji> = emptyList(),
+    /**
+     * The account that authored this status.
+     */
+    @SerializedName("account")
+    val account: Account? = null,
 
-    @SerializedName("replies_count")
-    val repliesCount: Int = 0,
+    /**
+     * HTML-encoded status content.
+     */
+    @SerializedName("content")
+    val content: String = "",
 
-    @SerializedName("reblogs_count")
-    val reblogsCount: Int = 0,
-
-    @SerializedName("favourites_count")
-    val favouritesCount: Int = 0,
-
-    @SerializedName("reblogged")
-    val isReblogged: Boolean = false,
-
-    @SerializedName("favourited")
-    val isFavourited: Boolean = false,
-
-    @SerializedName("sensitive")
-    val isSensitive: Boolean = false,
-
-    @SerializedName("spoiler_text")
-    val spoilerText: String = "",
-
+    /**
+     * Visibility of this status.
+     * @see Visibility
+     */
     @SerializedName("visibility")
     val visibility: String = Visibility.Public.value,
 
+    /**
+     * Is this status marked as sensitive content?
+     */
+    @SerializedName("sensitive")
+    val isSensitive: Boolean = false,
+
+    /**
+     * Subject or summary line, below which status content is collapsed until expanded.
+     */
+    @SerializedName("spoiler_text")
+    val spoilerText: String = "",
+
+    /**
+     * Media that is attached to this status.
+     */
     @SerializedName("media_attachments")
     val mediaAttachments: List<MediaAttachment> = emptyList(),
 
-    @SerializedName("mentions")
-    val mentions: List<Mention> = emptyList(),
-
-    @SerializedName("tags")
-    val tags: List<Tag> = emptyList(),
-
+    /**
+     * The application used to post this status (optional).
+     */
     @SerializedName("application")
     val application: Application? = null,
 
+    /**
+     * Mentions of users within the status content.
+     */
+    @SerializedName("mentions")
+    val mentions: List<Mention> = emptyList(),
+
+    /**
+     * Hashtags used within the status content.
+     */
+    @SerializedName("tags")
+    val tags: List<Tag> = emptyList(),
+
+    /**
+     * Custom emoji to be used when rendering status content.
+     */
+    @SerializedName("emojis")
+    val emojis: List<Emoji> = emptyList(),
+
+    /**
+     * How many boosts this status has received.
+     */
+    @SerializedName("reblogs_count")
+    val reblogsCount: Int = 0,
+
+    /**
+     * How many favourites this status has received.
+     */
+    @SerializedName("favourites_count")
+    val favouritesCount: Int = 0,
+
+    /**
+     * How many replies this status has received.
+     */
+    @SerializedName("replies_count")
+    val repliesCount: Int = 0,
+
+    /**
+     * A link to the status’s HTML representation.
+     */
+    @SerializedName("url")
+    val url: String = "",
+
+    /**
+     * ID of the status being replied to.
+     */
+    @SerializedName("in_reply_to_id")
+    val inReplyToId: String? = null,
+
+    /**
+     * ID of the account that authored the status being replied to.
+     */
+    @SerializedName("in_reply_to_account_id")
+    val inReplyToAccountId: String? = null,
+
+    /**
+     * The status being reblogged.
+     */
+    @SerializedName("reblog")
+    val reblog: Status? = null,
+
+    /**
+     * The poll attached to the status.
+     */
+    // poll
+
+    /**
+     * Preview card for links included within status content.
+     */
+    val card: PreviewCard? = null,
+
+    /**
+     * Primary language of this status (ISO 639 Part 1 two-letter language code).
+     */
     @SerializedName("language")
     val language: String? = null,
 
+    /**
+     * Plain-text source of a status. Returned instead of content when status is deleted, so the user may redraft from
+     * the source text without the client having to reverse-engineer the original text from the HTML content.
+     */
+    @SerializedName("text")
+    val text: String? = null,
+
+    /**
+     * Timestamp of when the status was last edited (ISO 8601 Datetime).
+     */
+    @SerializedName("edited_at")
+    val editedAt: String? = null,
+
+    /**
+     * If the current token has an authorized user: Have you favourited this status? (optional)
+     */
+    @SerializedName("favourited")
+    val isFavourited: Boolean = false,
+
+    /**
+     * If the current token has an authorized user: Have you boosted this status? (optional)
+     */
+    @SerializedName("reblogged")
+    val isReblogged: Boolean = false,
+
+    /**
+     * If the current token has an authorized user: Have you muted notifications for this status’s conversation? (optional)
+     */
+    @SerializedName("muted")
+    val isMuted: Boolean = false,
+
+    /**
+     * If the current token has an authorized user: Have you bookmarked this status? (optional)
+     */
+    @SerializedName("bookmarked")
+    val isBookmarked: Boolean = false,
+
+    /**
+     * If the current token has an authorized user: Have you pinned this status? Only appears if the status is pinnable. (optional)
+     */
     @SerializedName("pinned")
-    val pinned: Boolean? = null
+    val isPinned: Boolean? = null
+
+    /**
+     * If the current token has an authorized user: The filter and keywords that matched this status. (optional)
+     */
+    // filtered
 ) {
     enum class Visibility(val value: String) {
         Public("public"),

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
@@ -6,8 +6,8 @@ import social.bigbone.Parameters
 import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
-import social.bigbone.api.entity.Card
 import social.bigbone.api.entity.Context
+import social.bigbone.api.entity.PreviewCard
 import social.bigbone.api.entity.Status
 import social.bigbone.api.exception.BigBoneRequestException
 
@@ -49,7 +49,7 @@ class StatusMethods(private val client: MastodonClient) {
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#card">Mastodon API documentation: methods/statuses/#card</a>
      */
     @Throws(BigBoneRequestException::class)
-    fun getCard(statusId: String): MastodonRequest<Card> {
+    fun getCard(statusId: String): MastodonRequest<PreviewCard> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses/$statusId/card",
             method = MastodonClient.Method.GET


### PR DESCRIPTION
This does not yet close 16, but at least adding the `text` field is necessary for #124, which is scheduled for 2.0.0

- adds: card, text, edited_at, muted, bookmarked - text is necessary for work on editing statuses (#124)
- does not add: poll, filtered - held up by #129 and #130, respectively
- renames Card to PreviewCard, according to Mastodon API