### PR TITLE
Re-enabled OAuth 2 password grant flow

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
@@ -2,6 +2,7 @@ package social.bigbone.rx
 
 import io.reactivex.rxjava3.core.Single
 import social.bigbone.MastodonClient
+import social.bigbone.api.Scope
 import social.bigbone.api.entity.auth.AccessToken
 import social.bigbone.api.method.OAuthMethods
 import social.bigbone.rx.extensions.onErrorIfNotDisposed
@@ -9,16 +10,32 @@ import social.bigbone.rx.extensions.onErrorIfNotDisposed
 class RxOAuthMethods(client: MastodonClient) {
     private val oauth = OAuthMethods(client)
 
-    fun getAccessToken(
+    fun getAccessTokenWithAuthorizationCodeGrant(
         clientId: String,
         clientSecret: String,
         redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
-        code: String,
-        grantType: String = "authorization_code"
+        code: String
     ): Single<AccessToken> {
         return Single.create {
             try {
-                val accessToken = oauth.getAccessToken(clientId, clientSecret, redirectUri, code, grantType)
+                val accessToken = oauth.getAccessTokenWithAuthorizationCodeGrant(clientId, clientSecret, redirectUri, code)
+                it.onSuccess(accessToken.execute())
+            } catch (throwable: Throwable) {
+                it.onErrorIfNotDisposed(throwable)
+            }
+        }
+    }
+
+    fun getAccessTokenWithPasswordGrant(
+        clientId: String,
+        clientSecret: String,
+        scope: Scope = Scope(Scope.Name.READ),
+        username: String,
+        password: String
+    ): Single<AccessToken> {
+        return Single.create {
+            try {
+                val accessToken = oauth.getAccessTokenWithPasswordGrant(clientId, clientSecret, scope, username, password)
                 it.onSuccess(accessToken.execute())
             } catch (throwable: Throwable) {
                 it.onErrorIfNotDisposed(throwable)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Account.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Account.kt
@@ -7,7 +7,7 @@ data class Account(
     val id: String = "0",
 
     @SerializedName("username")
-    val userName: String = "",
+    val username: String = "",
 
     @SerializedName("acct")
     val acct: String = "",

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
@@ -35,23 +35,21 @@ class OAuthMethods(private val client: MastodonClient) {
     }
 
     /**
-     * Obtain an access token, to be used during API calls that are not public.
+     * Obtain an access token using OAuth 2 authorization code grant type. To be used during API calls that are not public.
      * @param clientId The client ID, obtained during app registration.
      * @param clientSecret The client secret, obtained during app registration.
      * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
      *  which will display the authorization code to the user instead of redirecting to a web page.
      *  Must match one of the redirect_uris declared during app registration.
      * @param code A user authorization code, obtained via the URL received from getOAuthUrl()
-     * @param grantType See Mastodon API documentation for details. Defaults to "authorization_code".
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
     @JvmOverloads
-    fun getAccessToken(
+    fun getAccessTokenWithAuthorizationCodeGrant(
         clientId: String,
         clientSecret: String,
         redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
-        code: String,
-        grantType: String = "authorization_code"
+        code: String
     ): MastodonRequest<AccessToken> {
         return client.getMastodonRequest(
             endpoint = "oauth/token",
@@ -61,7 +59,38 @@ class OAuthMethods(private val client: MastodonClient) {
                 append("client_secret", clientSecret)
                 append("redirect_uri", redirectUri)
                 append("code", code)
-                append("grant_type", grantType)
+                append("grant_type", "authorization_code")
+            }
+        )
+    }
+
+    /**
+     * Obtain an access token using OAuth 2 password grant type. To be used during API calls that are not public.
+     * @param clientId The client ID, obtained during app registration.
+     * @param clientSecret The client secret, obtained during app registration.
+     * @param scope Requested OAuth scopes
+     * @param username The Mastodon account username.
+     * @param password The Mastodon account password.
+     * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
+     */
+    @JvmOverloads
+    fun getAccessTokenWithPasswordGrant(
+        clientId: String,
+        clientSecret: String,
+        scope: Scope = Scope(Scope.Name.READ),
+        username: String,
+        password: String
+    ): MastodonRequest<AccessToken> {
+        return client.getMastodonRequest(
+            endpoint = "oauth/token",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("client_id", clientId)
+                append("client_secret", clientSecret)
+                append("scope", scope.toString())
+                append("username", username)
+                append("password", password)
+                append("grant_type", "password")
             }
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
@@ -65,7 +65,8 @@ class OAuthMethods(private val client: MastodonClient) {
     }
 
     /**
-     * Obtain an access token using OAuth 2 password grant type. To be used during API calls that are not public.
+     * Obtain an access token using OAuth 2 password grant type, to be used for bots and other single-user applications.
+     * Where possible, [getAccessTokenWithAuthorizationCodeGrant] should be used instead.
      * @param clientId The client ID, obtained during app registration.
      * @param clientSecret The client secret, obtained during app registration.
      * @param scope Requested OAuth scopes

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AccountMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AccountMethodsTest.kt
@@ -14,7 +14,7 @@ class AccountMethodsTest {
         val account = accountMethods.getAccount("1").execute()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test
@@ -33,7 +33,7 @@ class AccountMethodsTest {
         val account = accountMethods.verifyCredentials().execute()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test
@@ -54,7 +54,7 @@ class AccountMethodsTest {
         val account = accountMethods.updateCredentials("test", "test", "test", "test").execute()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test
@@ -74,7 +74,7 @@ class AccountMethodsTest {
         val account = pageable.part.first()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test
@@ -94,7 +94,7 @@ class AccountMethodsTest {
         val account = pageable.part.first()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test
@@ -287,7 +287,7 @@ class AccountMethodsTest {
         val account = result.first()
         account.acct shouldBeEqualTo "A"
         account.displayName shouldBeEqualTo ""
-        account.userName shouldBeEqualTo "A"
+        account.username shouldBeEqualTo "A"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/BlockMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/BlockMethodsTest.kt
@@ -16,7 +16,7 @@ class BlockMethodsTest {
         val block = pageable.part.first()
         block.acct shouldBeEqualTo "test@test.com"
         block.displayName shouldBeEqualTo "test"
-        block.userName shouldBeEqualTo "test"
+        block.username shouldBeEqualTo "test"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/FollowRequestMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/FollowRequestMethodsTest.kt
@@ -16,7 +16,7 @@ class FollowRequestMethodsTest {
         val account = pageable.part.first()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/MuteMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/MuteMethodsTest.kt
@@ -15,7 +15,7 @@ class MuteMethodsTest {
         val account = pageable.part.first()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
@@ -10,6 +10,7 @@ import social.bigbone.api.Scope
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
 
+@Suppress("FunctionMaxLength")
 class OAuthMethodsTest {
 
     @Test
@@ -23,11 +24,11 @@ class OAuthMethodsTest {
     }
 
     @Test
-    fun getAccessToken() {
+    fun getAccessTokenWithAuthorizationCodeGrant() {
         val client: MastodonClient = MockClient.mock("access_token.json")
         every { client.getInstanceName() } returns "mastodon.cloud"
         val oauth = OAuthMethods(client)
-        val accessToken = oauth.getAccessToken("test", "test", code = "test").execute()
+        val accessToken = oauth.getAccessTokenWithAuthorizationCodeGrant("test", "test", code = "test").execute()
         accessToken.accessToken shouldBeEqualTo "test"
         accessToken.scope shouldBeEqualTo "read write follow"
         accessToken.tokenType shouldBeEqualTo "bearer"
@@ -35,12 +36,34 @@ class OAuthMethodsTest {
     }
 
     @Test
-    fun getAccessTokenWithException() {
+    fun getAccessTokenWithAuthorizationCodeGrantWithException() {
         Assertions.assertThrows(BigBoneRequestException::class.java) {
             val client: MastodonClient = MockClient.ioException()
             every { client.getInstanceName() } returns "mastodon.cloud"
             val oauth = OAuthMethods(client)
-            oauth.getAccessToken("test", "test", code = "test").execute()
+            oauth.getAccessTokenWithAuthorizationCodeGrant("test", "test", code = "test").execute()
+        }
+    }
+
+    @Test
+    fun getAccessTokenWithPasswordGrant() {
+        val client: MastodonClient = MockClient.mock("access_token.json")
+        every { client.getInstanceName() } returns "mastodon.cloud"
+        val oauth = OAuthMethods(client)
+        val accessToken = oauth.getAccessTokenWithPasswordGrant("test", "test", Scope(Scope.Name.ALL), "test", "test").execute()
+        accessToken.accessToken shouldBeEqualTo "test"
+        accessToken.scope shouldBeEqualTo "read write follow"
+        accessToken.tokenType shouldBeEqualTo "bearer"
+        accessToken.createdAt shouldBeEqualTo 1_493_188_835
+    }
+
+    @Test
+    fun getAccessTokenWithPasswordGrantWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client: MastodonClient = MockClient.ioException()
+            every { client.getInstanceName() } returns "mastodon.cloud"
+            val oauth = OAuthMethods(client)
+            oauth.getAccessTokenWithPasswordGrant("test", "test", Scope(Scope.Name.ALL), "test", "test").execute()
         }
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/StatusMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/StatusMethodsTest.kt
@@ -71,7 +71,7 @@ class StatusMethodsTest {
         val account = pageable.part.first()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test
@@ -91,7 +91,7 @@ class StatusMethodsTest {
         val account = pageable.part.first()
         account.acct shouldBeEqualTo "test@test.com"
         account.displayName shouldBeEqualTo "test"
-        account.userName shouldBeEqualTo "test"
+        account.username shouldBeEqualTo "test"
     }
 
     @Test

--- a/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
@@ -1,13 +1,11 @@
 package social.bigbone.sample;
 
-import com.google.gson.Gson;
 import social.bigbone.MastodonClient;
-import social.bigbone.MastodonRequest;
-import social.bigbone.Parameters;
 import social.bigbone.api.Scope;
 import social.bigbone.api.entity.auth.AccessToken;
 import social.bigbone.api.entity.auth.AppRegistration;
 import social.bigbone.api.exception.BigBoneRequestException;
+import social.bigbone.api.method.OAuthMethods;
 
 import java.io.File;
 import java.io.IOException;
@@ -64,37 +62,12 @@ final class Authenticator {
 
     private static AccessToken getAccessToken(final String instanceName, final String clientId, final String clientSecret, final String email, final String password) throws BigBoneRequestException {
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
-        return postUserNameAndPassword(client, clientId, clientSecret, new Scope(), email, password).execute();
+        final OAuthMethods oauthMethods = new OAuthMethods(client);
+        return oauthMethods.getAccessTokenWithPasswordGrant(clientId, clientSecret, new Scope(), email, password).execute();
     }
 
     private static AppRegistration appRegistration(final String instanceName) throws BigBoneRequestException {
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
         return client.apps().createApp("bigbone-sample-app", "urn:ietf:wg:oauth:2.0:oob", new Scope(), null).execute();
-    }
-
-    /**
-     * Obtain an access token, to be used during API calls that are not public. This method uses a grant_type
-     * that is undocumented in Mastodon API, and should NOT be used in production code. It will be removed at a later date.
-     * Apps.getAccessToken() should be used instead.
-     */
-    private static MastodonRequest<AccessToken> postUserNameAndPassword(
-            final MastodonClient client,
-            final String clientId,
-            final String clientSecret,
-            final Scope scope,
-            final String userName,
-            final String password
-            ) {
-        final Parameters parameters = new Parameters()
-                .append("client_id", clientId)
-                .append("client_secret", clientSecret)
-                .append("scope", scope.toString())
-                .append("username", userName)
-                .append("password", password)
-                .append("grant_type", "password");
-        return new MastodonRequest<>(
-                () -> client.post("oauth/token", parameters),
-                s -> new Gson().fromJson(s, AccessToken.class)
-        );
     }
 }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
@@ -1,12 +1,10 @@
 package social.bigbone.sample
 
-import com.google.gson.Gson
 import social.bigbone.MastodonClient
-import social.bigbone.MastodonRequest
-import social.bigbone.Parameters
 import social.bigbone.api.Scope
 import social.bigbone.api.entity.auth.AccessToken
 import social.bigbone.api.entity.auth.AppRegistration
+import social.bigbone.api.method.OAuthMethods
 import java.io.File
 import java.util.Properties
 
@@ -72,7 +70,8 @@ object Authenticator {
         password: String
     ): AccessToken {
         val client = MastodonClient.Builder(instanceName).build()
-        return postUserNameAndPassword(client, clientId, clientSecret, Scope(), email, password).execute()
+        val oAuthMethods = OAuthMethods(client)
+        return oAuthMethods.getAccessTokenWithPasswordGrant(clientId, clientSecret, Scope(), email, password).execute()
     }
 
     private fun appRegistration(instanceName: String): AppRegistration {
@@ -81,35 +80,5 @@ object Authenticator {
             "bigbone-sample-app",
             scope = Scope()
         ).execute()
-    }
-
-    /**
-     * Obtain an access token, to be used during API calls that are not public. This method uses a grant_type
-     * that is undocumented in Mastodon API, and should NOT be used in production code. It will be removed at a later date.
-     * Apps.getAccessToken() should be used instead.
-     */
-    private fun postUserNameAndPassword(
-        client: MastodonClient,
-        clientId: String,
-        clientSecret: String,
-        scope: Scope,
-        userName: String,
-        password: String
-    ): MastodonRequest<AccessToken> {
-        val parameters = Parameters()
-            .append("client_id", clientId)
-            .append("client_secret", clientSecret)
-            .append("scope", scope.toString())
-            .append("username", userName)
-            .append("password", password)
-            .append("grant_type", "password")
-        return MastodonRequest(
-            {
-                client.post("oauth/token", parameters)
-            },
-            {
-                Gson().fromJson(it, AccessToken::class.java)
-            }
-        )
     }
 }


### PR DESCRIPTION
I have re-enabled the OAuth 2 password grant flow. Methods are now located in OAuthMethods classes, so it matches the location with Mastodon API docs. 

This PR also contains some minor cleanups (variable renaming), which is not directly related to issue https://github.com/andregasser/bigbone/issues/132