### PR TITLE
Do not store okhttp3.Response in BigBoneRequestException

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -283,7 +283,7 @@ private constructor(
             )
             return call.execute()
         } catch (e: IOException) {
-            throw BigBoneRequestException(e)
+            throw BigBoneRequestException("Request not executed due to network IO issue", e)
         }
     }
 
@@ -304,7 +304,7 @@ private constructor(
             )
             return call.execute()
         } catch (e: IOException) {
-            throw BigBoneRequestException(e)
+            throw BigBoneRequestException("Request not executed due to network IO issue", e)
         }
     }
 
@@ -315,7 +315,7 @@ private constructor(
      */
     fun patch(path: String, body: Parameters?): Response {
         if (body == null) {
-            throw BigBoneRequestException(Exception("body must not be empty"))
+            throw BigBoneRequestException("Patch request not possible with null body")
         }
 
         try {
@@ -329,7 +329,7 @@ private constructor(
             )
             return call.execute()
         } catch (e: IOException) {
-            throw BigBoneRequestException(e)
+            throw BigBoneRequestException("Request not executed due to network IO issue", e)
         }
     }
 
@@ -363,7 +363,7 @@ private constructor(
         } catch (e: IllegalArgumentException) {
             throw BigBoneRequestException(e)
         } catch (e: IOException) {
-            throw BigBoneRequestException(e)
+            throw BigBoneRequestException("Request not executed due to network IO issue", e)
         }
     }
 

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
@@ -71,7 +71,7 @@ class MastodonRequest<T>(
                     }
                 }
             } catch (e: Exception) {
-                throw BigBoneRequestException(e)
+                throw BigBoneRequestException("Successful response could not be parsed", e)
             }
         } else {
             throw BigBoneRequestException(response)

--- a/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneRequestException.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneRequestException.kt
@@ -4,24 +4,51 @@ import okhttp3.Response
 
 /**
  * Exception which is thrown when there was a problem executing the associated [social.bigbone.MastodonRequest].
- * Some additional error information is provided in the [response] property.
  */
 class BigBoneRequestException : Exception {
-    val response: Response?
+    /**
+     * If BigBoneRequestException was constructed using a [Response], this will be set to the HTTP status code of the
+     * unsuccessful request. Use [statusCodeValid] to check whether this contains valid information.
+     */
+    var httpStatusCode = invalidStatusCode
 
+    /**
+     * true if [httpStatusCode] contains a valid HTTP Status code, false if not.
+     */
+    val statusCodeValid: Boolean
+        get() {
+            return httpStatusCode != invalidStatusCode
+        }
+
+    /**
+     * Create a BigBoneRequestException using a [Response].
+     * @param response an unsuccessful response; the HTTP status message will be used as the detail message for this
+     * exception, HTTP status code will be available via [httpStatusCode].
+     */
     constructor(response: Response) : super(response.message) {
-        this.response = response
+        httpStatusCode = response.code
     }
 
-    constructor(e: Exception) : super(e) {
-        this.response = null
-    }
+    /**
+     * Create a BigBoneRequestException using another [Exception].
+     * @param e another exception
+     */
+    constructor(e: Exception) : super(e)
 
-    constructor(message: String) : super(message) {
-        this.response = null
-    }
+    /**
+     * Create a BigBoneRequestException using a message string.
+     * @param message the message string
+     */
+    constructor(message: String) : super(message)
 
-    constructor(message: String, e: Exception) : super(message, e) {
-        this.response = null
+    /**
+     * Create a BigBoneRequestException using another [Exception] and an additional message string.
+     * @param message the message string
+     * @param e another exception
+     */
+    constructor(message: String, e: Exception) : super(message, e)
+
+    companion object {
+        private const val invalidStatusCode = -1
     }
 }


### PR DESCRIPTION
- response.message is used as detail message of the built exception
- response.code is made available via httpStatusCode of the exception
- also: commenting all constructors of BigBoneRequestException
- also: provide additional message in many cases that previously just wrapped another exception

Closes #138