### PR TITLE
Add endpoint for retrieving client application access token

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
@@ -29,22 +29,28 @@ class AppMethods(private val client: MastodonClient) {
         website: String? = null
     ): MastodonRequest<Application> {
         scope.validate()
-
-        val parameters = Parameters()
-            .append("client_name", clientName)
-            .append("scopes", scope.toString())
-            .append("redirect_uris", redirectUris)
-        website?.let {
-            parameters.append("website", it)
-        }
-
-        return MastodonRequest(
-            {
-                client.post("api/v1/apps", parameters)
-            },
-            {
-                client.getSerializer().fromJson(it, Application::class.java)
+        return client.getMastodonRequest(
+            endpoint = "api/v1/apps",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("client_name", clientName)
+                append("scopes", scope.toString())
+                append("redirect_uris", redirectUris)
+                website?.let {
+                    append("website", it)
+                }
             }
+        )
+    }
+
+    /**
+     * Confirm that the app’s OAuth2 credentials work.
+     * @see <a href="https://docs.joinmastodon.org/methods/apps/#verify_credentials">Mastodon API documentation: methods/apps/#verify_credentials</a>
+     */
+    fun verifyCredentials(): MastodonRequest<Application> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/apps/verify_credentials",
+            method = MastodonClient.Method.GET
         )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
@@ -59,7 +59,41 @@ class OAuthMethods(private val client: MastodonClient) {
                 append("client_secret", clientSecret)
                 append("redirect_uri", redirectUri)
                 append("code", code)
-                append("grant_type", "authorization_code")
+                append("grant_type", GrantTypes.AUTHORIZATION_CODE.value)
+            }
+        )
+    }
+
+    /**
+     * Obtain an access token using OAuth 2 client credentials grant type. To be used during API calls that are not public.
+     * @param clientId The client ID, obtained during app registration.
+     * @param clientSecret The client secret, obtained during app registration.
+     * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
+     *  which will display the authorization code to the user instead of redirecting to a web page.
+     *  Must match one of the redirect_uris declared during app registration.
+     * @param scope Requested OAuth scopes. Must be a subset of scopes declared during app registration.
+     *  If not provided, defaults to read.
+     * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
+     * @see <a href="https://docs.joinmastodon.org/client/token/#methods">Usage of this authentication form</a>
+     */
+    @JvmOverloads
+    fun getAccessTokenWithClientCredentialsGrant(
+        clientId: String,
+        clientSecret: String,
+        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        scope: Scope? = null
+    ): MastodonRequest<Token> {
+        return client.getMastodonRequest(
+            endpoint = "oauth/token",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("client_id", clientId)
+                append("client_secret", clientSecret)
+                append("redirect_uri", redirectUri)
+                scope?.let {
+                    append("scope", it.toString())
+                }
+                append("grant_type", GrantTypes.CLIENT_CREDENTIALS.value)
             }
         )
     }
@@ -91,8 +125,19 @@ class OAuthMethods(private val client: MastodonClient) {
                 append("scope", scope.toString())
                 append("username", username)
                 append("password", password)
-                append("grant_type", "password")
+                append("grant_type", GrantTypes.PASSWORD.value)
             }
         )
+    }
+
+    companion object {
+        /**
+         * Possible grant types and respective parameter values used when requesting an access token.
+         */
+        private enum class GrantTypes(val value: String) {
+            AUTHORIZATION_CODE("authorization_code"),
+            CLIENT_CREDENTIALS("client_credentials"),
+            PASSWORD("password")
+        }
     }
 }

--- a/bigbone/src/test/assets/app_registration.json
+++ b/bigbone/src/test/assets/app_registration.json
@@ -1,6 +1,0 @@
-{
-  "id": 4137,
-  "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
-  "client_id": "client id",
-  "client_secret": "client secret"
-}

--- a/bigbone/src/test/assets/application.json
+++ b/bigbone/src/test/assets/application.json
@@ -1,0 +1,7 @@
+{
+  "name": "bigbone-sample-app",
+  "website": null,
+  "vapid_key": "vapid key",
+  "client_id": "client id",
+  "client_secret": "client secret"
+}

--- a/bigbone/src/test/assets/application_no_client_data.json
+++ b/bigbone/src/test/assets/application_no_client_data.json
@@ -1,0 +1,5 @@
+{
+  "name": "bigbone-sample-app",
+  "website": null,
+  "vapid_key": "vapid key"
+}

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
@@ -12,7 +12,7 @@ import social.bigbone.testtool.MockClient
 class AppMethodsTest {
     @Test
     fun createApp() {
-        val client: MastodonClient = MockClient.mock("app_registration.json")
+        val client: MastodonClient = MockClient.mock("application.json")
         every { client.getInstanceName() } returns "mastodon.cloud"
 
         val appMethods = AppMethods(client)
@@ -32,6 +32,26 @@ class AppMethodsTest {
             appMethods.createApp(
                 clientName = "bigbone-sample-app", scope = Scope(Scope.Name.ALL)
             ).execute()
+        }
+    }
+
+    @Test
+    fun verifyCredentials() {
+        val client: MastodonClient = MockClient.mock("application_no_client_data.json")
+        every { client.getInstanceName() } returns "mastodon.cloud"
+
+        val appMethods = AppMethods(client)
+        val application = appMethods.verifyCredentials().execute()
+
+        application.name shouldBeEqualTo "bigbone-sample-app"
+    }
+
+    @Test
+    fun verifyCredentialsWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val appMethods = AppMethods(client)
+            appMethods.verifyCredentials().execute()
         }
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
@@ -46,6 +46,28 @@ class OAuthMethodsTest {
     }
 
     @Test
+    fun getAccessTokenWithClientCredentialsGrant() {
+        val client: MastodonClient = MockClient.mock("access_token.json")
+        every { client.getInstanceName() } returns "mastodon.cloud"
+        val oauth = OAuthMethods(client)
+        val accessToken = oauth.getAccessTokenWithClientCredentialsGrant("test", "test").execute()
+        accessToken.accessToken shouldBeEqualTo "test"
+        accessToken.scope shouldBeEqualTo "read write follow"
+        accessToken.tokenType shouldBeEqualTo "bearer"
+        accessToken.createdAt shouldBeEqualTo 1_493_188_835
+    }
+
+    @Test
+    fun getAccessTokenWithClientCredentialsGrantWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client: MastodonClient = MockClient.ioException()
+            every { client.getInstanceName() } returns "mastodon.cloud"
+            val oauth = OAuthMethods(client)
+            oauth.getAccessTokenWithClientCredentialsGrant("test", "test").execute()
+        }
+    }
+
+    @Test
     fun getAccessTokenWithPasswordGrant() {
         val client: MastodonClient = MockClient.mock("access_token.json")
         every { client.getInstanceName() } returns "mastodon.cloud"


### PR DESCRIPTION
- adds OAuth method getAccessTokenWithClientCredentialsGrant
- adds Apps method verifyCredentials to confirm result of the above method
- tests for both methods
- moves/splits test data to application.json and application_no_client_data.json, following previous rename from AppRegistration to Application

Closes #142.