### PR TITLE
Remove specific default limit from Range

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/Range.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Range.kt
@@ -5,10 +5,14 @@ import social.bigbone.Parameters
 /**
  * A range can be used to narrow down the data to be returned by the Mastodon API.
  */
-class Range @JvmOverloads constructor(val maxId: String? = null, val sinceId: String? = null, val limit: Int = 20) {
+class Range @JvmOverloads constructor(
+    val maxId: String? = null,
+    val sinceId: String? = null,
+    val limit: Int? = null
+) {
     fun toParameters() = Parameters().apply {
         maxId?.let { append("max_id", it) }
         sinceId?.let { append("since_id", it) }
-        append("limit", limit)
+        limit?.let { append("limit", it) }
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/RangeTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/RangeTest.kt
@@ -8,12 +8,12 @@ class RangeTest {
     fun toParameter() {
         run {
             val range = Range()
-            range.toParameters().toQuery() shouldBeEqualTo "limit=20"
+            range.toParameters().toQuery() shouldBeEqualTo ""
         }
 
         run {
             val range = Range(maxId = "10")
-            range.toParameters().toQuery() shouldBeEqualTo "max_id=10&limit=20"
+            range.toParameters().toQuery() shouldBeEqualTo "max_id=10"
         }
 
         run {


### PR DESCRIPTION
Mastodon has different default limits depending on the type of entity returned by an endpoint. Not specifying any limit means that the server-side default will be used instead, which is a better default than what we had before.

Closes #141