### PR TITLE
Add missing Status methods, except for Status editing

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
@@ -41,6 +41,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun translateStatus(statusId: String, language: String? = null): Single<Translation> {
         return Single.create {
             try {
@@ -52,6 +53,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun getRebloggedBy(statusId: String, range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {
@@ -63,7 +65,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
-    //  GET /api/v1/favourited_by
+    @JvmOverloads
     fun getFavouritedBy(statusId: String, range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {
@@ -75,6 +77,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun postStatus(
         status: String,
         inReplyToId: String? = null,
@@ -94,6 +97,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun postPoll(
         status: String,
         pollOptions: List<String>,
@@ -127,6 +131,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun scheduleStatus(
         status: String,
         inReplyToId: String? = null,
@@ -147,6 +152,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun schedulePoll(
         status: String,
         pollOptions: List<String>,
@@ -193,6 +199,7 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun reblogStatus(statusId: String, visibility: Status.Visibility = Status.Visibility.Public): Single<Status> {
         return Single.create {
             try {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
@@ -1,14 +1,14 @@
 package social.bigbone.rx
 
-import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Single
 import social.bigbone.MastodonClient
 import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.api.entity.Context
-import social.bigbone.api.entity.PreviewCard
+import social.bigbone.api.entity.ScheduledStatus
 import social.bigbone.api.entity.Status
+import social.bigbone.api.entity.Translation
 import social.bigbone.api.method.StatusMethods
 
 /**
@@ -41,11 +41,11 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
-    fun getCard(statusId: String): Single<PreviewCard> {
+    fun translateStatus(statusId: String, language: String? = null): Single<Translation> {
         return Single.create {
             try {
-                val context = statusMethods.getCard(statusId)
-                it.onSuccess(context.execute())
+                val translation = statusMethods.translateStatus(statusId, language)
+                it.onSuccess(translation.execute())
             } catch (e: Throwable) {
                 it.onError(e)
             }
@@ -81,11 +81,12 @@ class RxStatusMethods(client: MastodonClient) {
         mediaIds: List<String>? = null,
         sensitive: Boolean = false,
         spoilerText: String? = null,
-        visibility: Status.Visibility = Status.Visibility.Public
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String? = null
     ): Single<Status> {
         return Single.create {
             try {
-                val result = statusMethods.postStatus(status, inReplyToId, mediaIds, sensitive, spoilerText, visibility)
+                val result = statusMethods.postStatus(status, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language)
                 it.onSuccess(result.execute())
             } catch (e: Throwable) {
                 it.onError(e)
@@ -93,21 +94,109 @@ class RxStatusMethods(client: MastodonClient) {
         }
     }
 
-    fun deleteStatus(statusId: String): Completable {
-        return Completable.create {
+    fun postPoll(
+        status: String,
+        pollOptions: List<String>,
+        pollExpiresIn: Int,
+        pollMultiple: Boolean = false,
+        pollHideTotals: Boolean = false,
+        inReplyToId: String? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String? = null
+    ): Single<Status> {
+        return Single.create {
             try {
-                statusMethods.deleteStatus(statusId)
-                it.onComplete()
+                val result = statusMethods.postPoll(
+                    status,
+                    pollOptions,
+                    pollExpiresIn,
+                    pollMultiple,
+                    pollHideTotals,
+                    inReplyToId,
+                    sensitive,
+                    spoilerText,
+                    visibility,
+                    language
+                )
+                it.onSuccess(result.execute())
             } catch (e: Throwable) {
                 it.onError(e)
             }
         }
     }
 
-    fun reblogStatus(statusId: String): Single<Status> {
+    fun scheduleStatus(
+        status: String,
+        inReplyToId: String? = null,
+        mediaIds: List<String>? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String? = null,
+        scheduledAt: String
+    ): Single<ScheduledStatus> {
         return Single.create {
             try {
-                val status = statusMethods.reblogStatus(statusId)
+                val result = statusMethods.scheduleStatus(status, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language, scheduledAt)
+                it.onSuccess(result.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun schedulePoll(
+        status: String,
+        pollOptions: List<String>,
+        pollExpiresIn: Int,
+        pollMultiple: Boolean = false,
+        pollHideTotals: Boolean = false,
+        inReplyToId: String? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String? = null,
+        scheduledAt: String
+    ): Single<ScheduledStatus> {
+        return Single.create {
+            try {
+                val result = statusMethods.schedulePoll(
+                    status,
+                    pollOptions,
+                    pollExpiresIn,
+                    pollMultiple,
+                    pollHideTotals,
+                    inReplyToId,
+                    sensitive,
+                    spoilerText,
+                    visibility,
+                    language,
+                    scheduledAt
+                )
+                it.onSuccess(result.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun deleteStatus(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.deleteStatus(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun reblogStatus(statusId: String, visibility: Status.Visibility = Status.Visibility.Public): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.reblogStatus(statusId, visibility)
                 it.onSuccess(status.execute())
             } catch (e: Throwable) {
                 it.onError(e)
@@ -141,6 +230,72 @@ class RxStatusMethods(client: MastodonClient) {
         return Single.create {
             try {
                 val status = statusMethods.unfavouriteStatus(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun bookmarkStatus(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.bookmarkStatus(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun unbookmarkStatus(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.unbookmarkStatus(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun muteConversation(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.muteConversation(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun unmuteConversation(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.unmuteConversation(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun pinStatus(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.pinStatus(statusId)
+                it.onSuccess(status.execute())
+            } catch (e: Throwable) {
+                it.onError(e)
+            }
+        }
+    }
+
+    fun unpinStatus(statusId: String): Single<Status> {
+        return Single.create {
+            try {
+                val status = statusMethods.unpinStatus(statusId)
                 it.onSuccess(status.execute())
             } catch (e: Throwable) {
                 it.onError(e)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Poll.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Poll.kt
@@ -1,0 +1,86 @@
+package social.bigbone.api.entity
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a poll attached to a status.
+ */
+data class Poll(
+    /**
+     * The ID of the poll in the database.
+     */
+    @SerializedName("id")
+    val id: String = "",
+
+    /**
+     * When the poll ends. ISO 8601 Datetime string, or null if the poll does not end.
+     */
+    @SerializedName("expires_at")
+    val expiresAt: String? = null,
+
+    /**
+     * Is the poll currently expired?
+     */
+    @SerializedName("expired")
+    val expired: Boolean = false,
+
+    /**
+     * Does the poll allow multiple-choice answers?
+     */
+    @SerializedName("multiple")
+    val multiple: Boolean = false,
+
+    /**
+     * How many votes have been received.
+     */
+    @SerializedName("votes_count")
+    val votesCount: Int = 0,
+
+    /**
+     * How many unique accounts have voted on a multiple-choice poll; integer, or null if [multiple] is false.
+     */
+    @SerializedName("voters_count")
+    val votersCount: Int? = null,
+
+    /**
+     * Possible answers for the poll.
+     */
+    @SerializedName("options")
+    val options: List<Option> = emptyList(),
+
+    /**
+     * Custom emoji to be used for rendering poll options.
+     */
+    @SerializedName("emojis")
+    val emojis: List<CustomEmoji> = emptyList(),
+
+    /**
+     * When called with a user token, has the authorized user voted?
+     */
+    @SerializedName("voted")
+    val voted: Boolean? = null,
+
+    /**
+     * When called with a user token, which options has the authorized user chosen? Contains an array of index values for [options].
+     */
+    @SerializedName("own_votes")
+    val ownVotes: List<Int>? = null
+
+) {
+    /**
+     * Possible answers for the poll.
+     */
+    data class Option(
+        /**
+         * The text value of the poll option.
+         */
+        @SerializedName("title")
+        val title: String = "",
+
+        /**
+         * The total number of received votes for this option; integer, or null if results are not published yet.
+         */
+        @SerializedName("votes_count")
+        val votesCount: Int? = null
+    )
+}

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Poll.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Poll.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 /**
  * Represents a poll attached to a status.
+ * @see <a href="https://docs.joinmastodon.org/entities/Poll/">Mastodon API Poll</a>
  */
 data class Poll(
     /**
@@ -69,6 +70,7 @@ data class Poll(
 ) {
     /**
      * Possible answers for the poll.
+     * @see <a href="https://docs.joinmastodon.org/entities/Poll/#Option">Mastodon API Poll::Option</a>
      */
     data class Option(
         /**

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/ScheduledStatus.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/ScheduledStatus.kt
@@ -1,0 +1,138 @@
+package social.bigbone.api.entity
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a status that will be published at a future scheduled date.
+ */
+data class ScheduledStatus(
+    /**
+     * ID of the scheduled status in the database.
+     */
+    @SerializedName("id")
+    val id: String = "",
+
+    /**
+     * The timestamp for when the status will be posted (ISO 8601 Datetime).
+     */
+    @SerializedName("scheduled_at")
+    val scheduledAt: String = "",
+
+    /**
+     * The parameters that were used when scheduling the status, to be used when the status is posted.
+     */
+    @SerializedName("params")
+    val params: Parameters,
+
+    /**
+     * Media that will be attached when the status is posted.
+     */
+    @SerializedName("media_attachments")
+    val mediaAttachments: List<MediaAttachment> = emptyList()
+) {
+    /**
+     * The parameters that were used when scheduling the status, to be used when the status is posted.
+     */
+    data class Parameters(
+        /**
+         * Text to be used as status content.
+         */
+        @SerializedName("text")
+        val text: String = "",
+
+        /**
+         * Poll to be attached to the status.
+         */
+        @SerializedName("poll")
+        val poll: Poll? = null,
+
+        /**
+         * IDs of the MediaAttachments that will be attached to the status.
+         */
+        @SerializedName("media_ids")
+        val mediaIds: List<String>? = null,
+
+        /**
+         * Whether the status will be marked as sensitive.
+         */
+        @SerializedName("sensitive")
+        val sensitive: Boolean? = null,
+
+        /**
+         * The text of the content warning or summary for the status.
+         */
+        @SerializedName("spoiler_text")
+        val spoilerText: String = "",
+
+        /**
+         * The visibility that the status will have once it is posted.
+         */
+        @SerializedName("visibility")
+        val visibility: String = Status.Visibility.Public.value,
+
+        /**
+         * ID of the Status that will be replied to.
+         */
+        @SerializedName("in_reply_to_id")
+        val inReplyToId: String? = null,
+
+        /**
+         * The language that will be used for the status (ISO 639-1 two-letter language code).
+         */
+        @SerializedName("language")
+        val language: String? = null,
+
+        /**
+         * ID of the Application that posted the status.
+         */
+        @SerializedName("application_id")
+        val applicationId: Int = 0,
+
+        /**
+         * When the status will be scheduled. This will be null because the status is only scheduled once.
+         */
+        @SerializedName("scheduled_at")
+        val scheduledAt: String? = null,
+
+        /**
+         * Idempotency key to prevent duplicate statuses.
+         */
+        @SerializedName("idempotency")
+        val idempotency: String? = null,
+
+        /**
+         * Whether the status should be rate limited.
+         */
+        @SerializedName("with_rate_limit")
+        val withRateLimit: Boolean = false
+    )
+
+    /**
+     * Poll to be attached to the status.
+     */
+    data class Poll(
+        /**
+         * The poll options to be used.
+         */
+        @SerializedName("options")
+        val options: List<String> = emptyList(),
+
+        /**
+         * How many seconds the poll should last before closing (String cast from Integer).
+         */
+        @SerializedName("expires_in")
+        val expiresIn: String = "",
+
+        /**
+         * Whether the poll allows multiple choices.
+         */
+        @SerializedName("multiple")
+        val multiple: Boolean? = null,
+
+        /**
+         * Whether the poll should hide total votes until after voting has ended.
+         */
+        @SerializedName("hide_totals")
+        val hideTotals: Boolean? = null
+    )
+}

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/ScheduledStatus.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/ScheduledStatus.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 /**
  * Represents a status that will be published at a future scheduled date.
+ * @see <a href="https://docs.joinmastodon.org/entities/ScheduledStatus/">Mastodon API ScheduledStatus</a>
  */
 data class ScheduledStatus(
     /**
@@ -32,6 +33,7 @@ data class ScheduledStatus(
 ) {
     /**
      * The parameters that were used when scheduling the status, to be used when the status is posted.
+     * @see <a href="https://docs.joinmastodon.org/entities/ScheduledStatus/#params">Mastodon API ScheduledStatus params</a>
      */
     data class Parameters(
         /**
@@ -113,6 +115,7 @@ data class ScheduledStatus(
     data class Poll(
         /**
          * The poll options to be used.
+         * @see <a href="https://docs.joinmastodon.org/entities/ScheduledStatus/#params-poll">Mastodon API ScheduledStatus params-poll</a>
          */
         @SerializedName("options")
         val options: List<String> = emptyList(),

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Status.kt
@@ -131,7 +131,8 @@ data class Status(
     /**
      * The poll attached to the status.
      */
-    // poll
+    @SerializedName("poll")
+    val poll: Poll? = null,
 
     /**
      * Preview card for links included within status content.

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Translation.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Translation.kt
@@ -1,0 +1,26 @@
+package social.bigbone.api.entity
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents the result of machine translating some status content.
+ */
+data class Translation(
+    /**
+     * The translated text of the status as an HTML string.
+     */
+    @SerializedName("content")
+    val content: String = "",
+
+    /**
+     * The language of the source text, as auto-detected by the machine translation provider (ISO 639 language code).
+     */
+    @SerializedName("detected_source_language")
+    val detectedSourceLanguage: String = "",
+
+    /**
+     * The service that provided the machine translation.
+     */
+    @SerializedName("provider")
+    val provider: String = ""
+)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Translation.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Translation.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 /**
  * Represents the result of machine translating some status content.
+ * @see <a href="https://docs.joinmastodon.org/entities/Translation/">Mastodon API Translation</a>
  */
 data class Translation(
     /**

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
@@ -50,6 +50,7 @@ class StatusMethods(private val client: MastodonClient) {
      * @param language ISO 639 language code. The status content will be translated into this language. Defaults to the user’s current locale.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#translate">Mastodon API documentation: methods/statuses/#translate</a>
      */
+    @JvmOverloads
     @Throws(BigBoneRequestException::class)
     fun translateStatus(statusId: String, language: String? = null): MastodonRequest<Translation> {
         return client.getMastodonRequest(
@@ -287,6 +288,7 @@ class StatusMethods(private val client: MastodonClient) {
      *  Currently unused in UI.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#boost">Mastodon API documentation: methods/statuses/#boost</a>
      */
+    @JvmOverloads
     @Throws(BigBoneRequestException::class)
     fun reblogStatus(statusId: String, visibility: Status.Visibility = Status.Visibility.Public): MastodonRequest<Status> {
         if (visibility != Status.Visibility.Public &&

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
@@ -7,8 +7,9 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.api.entity.Context
-import social.bigbone.api.entity.PreviewCard
+import social.bigbone.api.entity.ScheduledStatus
 import social.bigbone.api.entity.Status
+import social.bigbone.api.entity.Translation
 import social.bigbone.api.exception.BigBoneRequestException
 
 /**
@@ -44,15 +45,19 @@ class StatusMethods(private val client: MastodonClient) {
     }
 
     /**
-     * Fetch preview card.
-     * @param statusId ID of the status.
-     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#card">Mastodon API documentation: methods/statuses/#card</a>
+     * Translate the status content into some language.
+     * @param statusId The ID of the Status in the database.
+     * @param language ISO 639 language code. The status content will be translated into this language. Defaults to the user’s current locale.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#translate">Mastodon API documentation: methods/statuses/#translate</a>
      */
     @Throws(BigBoneRequestException::class)
-    fun getCard(statusId: String): MastodonRequest<PreviewCard> {
+    fun translateStatus(statusId: String, language: String? = null): MastodonRequest<Translation> {
         return client.getMastodonRequest(
-            endpoint = "api/v1/statuses/$statusId/card",
-            method = MastodonClient.Method.GET
+            endpoint = "api/v1/statuses/$statusId/translate",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                language?.let { append("lang", it) }
+            }
         )
     }
 
@@ -89,13 +94,15 @@ class StatusMethods(private val client: MastodonClient) {
     }
 
     /**
-     * Publish a status with the given parameters.
+     * Publish a status with the given parameters. To publish a status containing a poll, use [postPoll].
+     * To schedule a status, use [scheduleStatus].
      * @param status the text of the status
      * @param inReplyToId the local id of the status you want to reply to
      * @param mediaIds the array of media ids to attach to the status (maximum 4)
      * @param sensitive set this to mark the media of the status as NSFW
      * @param spoilerText text to be shown as a warning before the actual content
      * @param visibility either "direct", "private", "unlisted" or "public"
+     * @param language ISO 639 language code for this status.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
      */
     @JvmOverloads
@@ -106,7 +113,8 @@ class StatusMethods(private val client: MastodonClient) {
         mediaIds: List<String>?,
         sensitive: Boolean,
         spoilerText: String?,
-        visibility: Status.Visibility = Status.Visibility.Public
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String?
     ): MastodonRequest<Status> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses",
@@ -118,6 +126,143 @@ class StatusMethods(private val client: MastodonClient) {
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
                 append("visibility", visibility.value)
+                language?.let { append("language", it) }
+            }
+        )
+    }
+
+    /**
+     * Publish a status containing a poll with the given parameters. To schedule a poll status, use [schedulePoll].
+     * @param status the text of the status
+     * @param pollOptions Possible answers to the poll.
+     * @param pollExpiresIn Duration that the poll should be open, in seconds.
+     * @param pollMultiple Allow multiple choices? Defaults to false.
+     * @param pollHideTotals Hide vote counts until the poll ends? Defaults to false.
+     * @param inReplyToId the local id of the status you want to reply to
+     * @param sensitive set this to mark the media of the status as NSFW
+     * @param spoilerText text to be shown as a warning before the actual content
+     * @param visibility either "direct", "private", "unlisted" or "public"
+     * @param language ISO 639 language code for this status.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
+     */
+    @JvmOverloads
+    @Throws(BigBoneRequestException::class)
+    fun postPoll(
+        status: String,
+        pollOptions: List<String>,
+        pollExpiresIn: Int,
+        pollMultiple: Boolean = false,
+        pollHideTotals: Boolean = false,
+        inReplyToId: String?,
+        sensitive: Boolean,
+        spoilerText: String?,
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String?
+    ): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("status", status)
+                append("poll[options]", pollOptions)
+                append("poll[expires_in]", pollExpiresIn)
+                append("poll[multiple]", pollMultiple)
+                append("poll[hide_totals", pollHideTotals)
+                inReplyToId?.let { append("in_reply_to_id", it) }
+                append("sensitive", sensitive)
+                spoilerText?.let { append("spoiler_text", it) }
+                append("visibility", visibility.value)
+                language?.let { append("language", it) }
+            }
+        )
+    }
+
+    /**
+     * Schedule a status with the given parameters. To schedule a status containing a poll, use [schedulePoll].
+     * To post a status immediately, use [postStatus].
+     * @param status the text of the status
+     * @param inReplyToId the local id of the status you want to reply to
+     * @param mediaIds the array of media ids to attach to the status (maximum 4)
+     * @param sensitive set this to mark the media of the status as NSFW
+     * @param spoilerText text to be shown as a warning before the actual content
+     * @param visibility either "direct", "private", "unlisted" or "public"
+     * @param language ISO 639 language code for this status.
+     * @param scheduledAt ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
+     */
+    @JvmOverloads
+    @Throws(BigBoneRequestException::class)
+    fun scheduleStatus(
+        status: String,
+        inReplyToId: String?,
+        mediaIds: List<String>?,
+        sensitive: Boolean,
+        spoilerText: String?,
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String?,
+        scheduledAt: String
+    ): MastodonRequest<ScheduledStatus> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("status", status)
+                inReplyToId?.let { append("in_reply_to_id", it) }
+                mediaIds?.let { append("media_ids", it) }
+                append("sensitive", sensitive)
+                spoilerText?.let { append("spoiler_text", it) }
+                append("visibility", visibility.value)
+                language?.let { append("language", it) }
+                append("scheduled_at", scheduledAt)
+            }
+        )
+    }
+
+    /**
+     * Schedule a status containing a poll with the given parameters. To post immediately, use [postPoll].
+     * @param status the text of the status
+     * @param pollOptions Possible answers to the poll.
+     * @param pollExpiresIn Duration that the poll should be open, in seconds.
+     * @param pollMultiple Allow multiple choices? Defaults to false.
+     * @param pollHideTotals Hide vote counts until the poll ends? Defaults to false.
+     * @param inReplyToId the local id of the status you want to reply to
+     * @param sensitive set this to mark the media of the status as NSFW
+     * @param spoilerText text to be shown as a warning before the actual content
+     * @param visibility either "direct", "private", "unlisted" or "public"
+     * @param language ISO 639 language code for this status.
+     * @param scheduledAt ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
+     */
+    @JvmOverloads
+    @Throws(BigBoneRequestException::class)
+    fun schedulePoll(
+        status: String,
+        pollOptions: List<String>,
+        pollExpiresIn: Int,
+        pollMultiple: Boolean = false,
+        pollHideTotals: Boolean = false,
+        inReplyToId: String?,
+        sensitive: Boolean,
+        spoilerText: String?,
+        visibility: Status.Visibility = Status.Visibility.Public,
+        language: String?,
+        scheduledAt: String
+    ): MastodonRequest<ScheduledStatus> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses",
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("status", status)
+                append("poll[options]", pollOptions)
+                append("poll[expires_in]", pollExpiresIn)
+                append("poll[multiple]", pollMultiple)
+                append("poll[hide_totals]", pollHideTotals)
+                inReplyToId?.let { append("in_reply_to_id", it) }
+                append("sensitive", sensitive)
+                spoilerText?.let { append("spoiler_text", it) }
+                append("visibility", visibility.value)
+                language?.let { append("language", it) }
+                append("scheduled_at", scheduledAt)
             }
         )
     }
@@ -128,8 +273,8 @@ class StatusMethods(private val client: MastodonClient) {
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#delete">Mastodon API documentation: methods/statuses/#delete</a>
      */
     @Throws(BigBoneRequestException::class)
-    fun deleteStatus(statusId: String) {
-        client.performAction(
+    fun deleteStatus(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
             endpoint = "api/v1/statuses/$statusId",
             method = MastodonClient.Method.DELETE
         )
@@ -138,13 +283,23 @@ class StatusMethods(private val client: MastodonClient) {
     /**
      * Reshare a status on your own profile.
      * @param statusId ID of the status.
+     * @param visibility Any visibility except limited or direct (i.e. public, unlisted, private). Defaults to public.
+     *  Currently unused in UI.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#boost">Mastodon API documentation: methods/statuses/#boost</a>
      */
     @Throws(BigBoneRequestException::class)
-    fun reblogStatus(statusId: String): MastodonRequest<Status> {
+    fun reblogStatus(statusId: String, visibility: Status.Visibility = Status.Visibility.Public): MastodonRequest<Status> {
+        if (visibility != Status.Visibility.Public &&
+            visibility != Status.Visibility.Unlisted &&
+            visibility != Status.Visibility.Private) {
+            throw BigBoneRequestException("Visibility must be one of: public, unlisted, private when reblogging.")
+        }
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses/$statusId/reblog",
-            method = MastodonClient.Method.POST
+            method = MastodonClient.Method.POST,
+            parameters = Parameters().apply {
+                append("visibility", visibility.value)
+            }
         )
     }
 
@@ -183,6 +338,84 @@ class StatusMethods(private val client: MastodonClient) {
     fun unfavouriteStatus(statusId: String): MastodonRequest<Status> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses/$statusId/unfavourite",
+            method = MastodonClient.Method.POST
+        )
+    }
+
+    /**
+     * Privately bookmark a status.
+     * @param statusId ID of the status.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#bookmark">Mastodon API documentation: methods/statuses/#bookmark</a>
+     */
+    @Throws(BigBoneRequestException::class)
+    fun bookmarkStatus(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/bookmark",
+            method = MastodonClient.Method.POST
+        )
+    }
+
+    /**
+     * Remove a status from your private bookmarks.
+     * @param statusId ID of the status.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#unbookmark">Mastodon API documentation: methods/statuses/#unbookmark</a>
+     */
+    @Throws(BigBoneRequestException::class)
+    fun unbookmarkStatus(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/unbookmark",
+            method = MastodonClient.Method.POST
+        )
+    }
+
+    /**
+     * Do not receive notifications for the thread that this status is part of. Must be a thread in which you are a participant.
+     * @param statusId ID of the status.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#mute">Mastodon API documentation: methods/statuses/#mute</a>
+     */
+    @Throws(BigBoneRequestException::class)
+    fun muteConversation(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/mute",
+            method = MastodonClient.Method.POST
+        )
+    }
+
+    /**
+     * Start receiving notifications again for the thread that this status is part of.
+     * @param statusId ID of the status.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#unmute">Mastodon API documentation: methods/statuses/#unmute</a>
+     */
+    @Throws(BigBoneRequestException::class)
+    fun unmuteConversation(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/unmute",
+            method = MastodonClient.Method.POST
+        )
+    }
+
+    /**
+     * Feature one of your own public statuses at the top of your profile.
+     * @param statusId The local ID of the Status in the database. The status should be authored by the authorized account.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#pin">Mastodon API documentation: methods/statuses/#pin</a>
+     */
+    @Throws(BigBoneRequestException::class)
+    fun pinStatus(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/pin",
+            method = MastodonClient.Method.POST
+        )
+    }
+
+    /**
+     * Unfeature a status from the top of your profile.
+     * @param statusId The local ID of the Status in the database.
+     * @see <a href="https://docs.joinmastodon.org/methods/statuses/#unpin">Mastodon API documentation: methods/statuses/#unpin</a>
+     */
+    @Throws(BigBoneRequestException::class)
+    fun unpinStatus(statusId: String): MastodonRequest<Status> {
+        return client.getMastodonRequest(
+            endpoint = "api/v1/statuses/$statusId/unpin",
             method = MastodonClient.Method.POST
         )
     }

--- a/bigbone/src/test/assets/card.json
+++ b/bigbone/src/test/assets/card.json
@@ -1,6 +1,0 @@
-{
-  "url": "The url associated with the card",
-  "title": "The title of the card",
-  "description": "The card description",
-  "image": "The image associated with the card, if any"
-}

--- a/bigbone/src/test/assets/scheduled_status.json
+++ b/bigbone/src/test/assets/scheduled_status.json
@@ -1,0 +1,19 @@
+{
+  "id": "12345",
+  "scheduled_at": "2023-12-31T12:34:56.789Z",
+  "params": {
+    "text": "test post",
+    "media_ids": null,
+    "sensitive": null,
+    "spoiler_text": null,
+    "visibility": null,
+    "language": null,
+    "scheduled_at": null,
+    "poll": null,
+    "idempotency": null,
+    "with_rate_limit": false,
+    "in_reply_to_id": null,
+    "application_id": 3
+  },
+  "media_attachments": []
+}

--- a/bigbone/src/test/assets/scheduled_status_with_poll.json
+++ b/bigbone/src/test/assets/scheduled_status_with_poll.json
@@ -1,0 +1,24 @@
+{
+  "id": "12345",
+  "scheduled_at": "2023-12-31T12:34:56.789Z",
+  "params": {
+    "text": "test post",
+    "media_ids": null,
+    "sensitive": null,
+    "spoiler_text": null,
+    "visibility": null,
+    "language": null,
+    "scheduled_at": null,
+    "poll": {
+      "options": ["foo", "bar", "baz"],
+      "expires_in": "3600",
+      "multiple": true,
+      "hideTotals": false
+    },
+    "idempotency": null,
+    "with_rate_limit": false,
+    "in_reply_to_id": null,
+    "application_id": 3
+  },
+  "media_attachments": []
+}

--- a/bigbone/src/test/assets/status_after_deleting.json
+++ b/bigbone/src/test/assets/status_after_deleting.json
@@ -1,0 +1,67 @@
+{
+  "id": "103254193998341330",
+  "created_at": "2019-12-05T08:19:26.052Z",
+  "in_reply_to_id": null,
+  "in_reply_to_account_id": null,
+  "sensitive": false,
+  "spoiler_text": "",
+  "visibility": "public",
+  "language": "en",
+  "uri": "test uri",
+  "url": "test url",
+  "replies_count": 0,
+  "reblogs_count": 0,
+  "favourites_count": 0,
+  "favourited": false,
+  "reblogged": false,
+  "muted": false,
+  "bookmarked": false,
+  "pinned": false,
+  "text": "status text after deletion",
+  "reblog": null,
+  "application": {
+    "name": "Web",
+    "website": null
+  },
+  "account": {
+    "id": "1",
+    "username": "foo",
+    "acct": "foo",
+    "display_name": "foo bar baz"
+  },
+  "media_attachments": [
+    {
+      "id": "22345792",
+      "type": "image",
+      "url": "https://files.mastodon.social/media_attachments/files/022/345/792/original/57859aede991da25.jpeg",
+      "preview_url": "https://files.mastodon.social/media_attachments/files/022/345/792/small/57859aede991da25.jpeg",
+      "remote_url": null,
+      "text_url": "https://mastodon.social/media/2N4uvkuUtPVrkZGysms",
+      "meta": {
+        "original": {
+          "width": 640,
+          "height": 480,
+          "size": "640x480",
+          "aspect": 1.3333333333333333
+        },
+        "small": {
+          "width": 461,
+          "height": 346,
+          "size": "461x346",
+          "aspect": 1.3323699421965318
+        },
+        "focus": {
+          "x": -0.27,
+          "y": 0.51
+        }
+      },
+      "description": "test media description",
+      "blurhash": "UFBWY:8_0Jxv4mx]t8t64.%M-:IUWGWAt6M}"
+    }
+  ],
+  "mentions": [],
+  "tags": [],
+  "emojis": [],
+  "card": null,
+  "poll": null
+}

--- a/bigbone/src/test/assets/status_with_poll.json
+++ b/bigbone/src/test/assets/status_with_poll.json
@@ -1,0 +1,61 @@
+{
+  "account": {
+    "acct": "test",
+    "avatar": "test",
+    "avatar_static": "test",
+    "created_at": "2017-04-13T13:09:20.869Z",
+    "display_name": "test",
+    "followers_count": 1,
+    "following_count": 0,
+    "header": "https://mstdn.jp/headers/original/missing.png",
+    "header_static": "https://mstdn.jp/headers/original/missing.png",
+    "id": "14476",
+    "locked": false,
+    "note": "test",
+    "statuses_count": 10,
+    "url": "https://mstdn.jp/test",
+    "username": "test"
+  },
+  "application": null,
+  "content": "Test Status",
+  "created_at": "2017-04-14T06:11:41.893Z",
+  "favourited": null,
+  "favourites_count": 0,
+  "id": "11111",
+  "in_reply_to_account_id": null,
+  "in_reply_to_id": null,
+  "media_attachments": [],
+  "mentions": [],
+  "reblog": null,
+  "reblogged": null,
+  "reblogs_count": 0,
+  "sensitive": false,
+  "spoiler_text": "",
+  "tags": [],
+  "uri": "tag:mstdn.jp,2017-04-14:objectId=172429:objectType=Status",
+  "url": "https://mstdn.jp/test",
+  "visibility": "public",
+  "poll": {
+    "id": "34830",
+    "expires_at": "2019-12-05T04:05:08.302Z",
+    "expired": true,
+    "multiple": false,
+    "votes_count": 10,
+    "voters_count": null,
+    "voted": true,
+    "own_votes": [
+      1
+    ],
+    "options": [
+      {
+        "title": "accept",
+        "votes_count": 6
+      },
+      {
+        "title": "deny",
+        "votes_count": 4
+      }
+    ],
+    "emojis": []
+  }
+}

--- a/bigbone/src/test/assets/translation.json
+++ b/bigbone/src/test/assets/translation.json
@@ -1,0 +1,5 @@
+{
+  "content": "<p>Hola mundo</p>",
+  "detected_source_language": "en",
+  "provider": "DeepL.com"
+}

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/StatusMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/StatusMethodsTest.kt
@@ -1,9 +1,9 @@
 package social.bigbone.api.method
 
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import social.bigbone.api.entity.Status
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
 
@@ -44,22 +44,21 @@ class StatusMethodsTest {
     }
 
     @Test
-    fun getCard() {
-        val client = MockClient.mock("card.json")
+    fun translateStatus() {
+        val client = MockClient.mock("translation.json")
         val statusMethods = StatusMethods(client)
-        val card = statusMethods.getCard("1").execute()
-        card.url shouldBeEqualTo "The url associated with the card"
-        card.title shouldBeEqualTo "The title of the card"
-        card.description shouldBeEqualTo "The card description"
-        card.image shouldNotBe null
+        val translation = statusMethods.translateStatus("statusId", "es").execute()
+        translation.content shouldBeEqualTo "<p>Hola mundo</p>"
+        translation.detectedSourceLanguage shouldBeEqualTo "en"
+        translation.provider shouldBeEqualTo "DeepL.com"
     }
 
     @Test
-    fun getCardWithExcetpion() {
+    fun translateStatusWithException() {
         Assertions.assertThrows(BigBoneRequestException::class.java) {
             val client = MockClient.ioException()
             val statusMethods = StatusMethods(client)
-            statusMethods.getCard("1").execute()
+            statusMethods.translateStatus("statusId", "es").execute()
         }
     }
 
@@ -107,7 +106,15 @@ class StatusMethodsTest {
     fun postStatus() {
         val client = MockClient.mock("status.json")
         val statusMethods = StatusMethods(client)
-        val status = statusMethods.postStatus("a", null, null, false, null).execute()
+        val status = statusMethods.postStatus(
+            status = "a",
+            inReplyToId = null,
+            mediaIds = null,
+            sensitive = false,
+            spoilerText = null,
+            visibility = Status.Visibility.Unlisted,
+            language = "en"
+        ).execute()
         status.id shouldBeEqualTo "11111"
     }
 
@@ -116,7 +123,140 @@ class StatusMethodsTest {
         Assertions.assertThrows(BigBoneRequestException::class.java) {
             val client = MockClient.ioException()
             val statusMethods = StatusMethods(client)
-            statusMethods.postStatus("a", null, null, false, null).execute()
+            statusMethods.postStatus(
+                status = "a",
+                inReplyToId = null,
+                mediaIds = null,
+                sensitive = false,
+                spoilerText = null,
+                visibility = Status.Visibility.Unlisted,
+                language = "en"
+            ).execute()
+        }
+    }
+
+    @Test
+    fun postPoll() {
+        val client = MockClient.mock("status_with_poll.json")
+        val statusMethods = StatusMethods(client)
+        val pollOptions = listOf("foo", "bar", "baz")
+        val status = statusMethods.postPoll(
+            status = "a",
+            pollOptions = pollOptions,
+            pollExpiresIn = 3600,
+            pollMultiple = false,
+            pollHideTotals = false,
+            inReplyToId = null,
+            sensitive = false,
+            spoilerText = null,
+            visibility = Status.Visibility.Unlisted,
+            language = "en"
+        ).execute()
+        status.poll?.id shouldBeEqualTo "34830"
+        status.poll?.expired shouldBeEqualTo true
+        status.poll?.votesCount shouldBeEqualTo 10
+        status.poll?.options?.get(0)?.votesCount shouldBeEqualTo 6
+    }
+
+    @Test
+    fun postPollWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            val pollOptions = listOf("foo", "bar", "baz")
+            statusMethods.postPoll(
+                status = "a",
+                pollOptions = pollOptions,
+                pollExpiresIn = 3600,
+                pollMultiple = false,
+                pollHideTotals = false,
+                inReplyToId = null,
+                sensitive = false,
+                spoilerText = null,
+                visibility = Status.Visibility.Unlisted,
+                language = "en"
+            ).execute()
+        }
+    }
+
+    @Test
+    fun scheduleStatus() {
+        val client = MockClient.mock("scheduled_status.json")
+        val statusMethods = StatusMethods(client)
+        val scheduledStatus = statusMethods.scheduleStatus(
+            status = "a",
+            inReplyToId = null,
+            mediaIds = null,
+            sensitive = false,
+            spoilerText = null,
+            visibility = Status.Visibility.Unlisted,
+            language = "en",
+            scheduledAt = "2023-12-31T12:34:56.789Z"
+        ).execute()
+        scheduledStatus.id shouldBeEqualTo "12345"
+        scheduledStatus.scheduledAt shouldBeEqualTo "2023-12-31T12:34:56.789Z"
+        scheduledStatus.params.text shouldBeEqualTo "test post"
+    }
+
+    @Test
+    fun scheduleStatusWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.scheduleStatus(
+                status = "a",
+                inReplyToId = null,
+                mediaIds = null,
+                sensitive = false,
+                spoilerText = null,
+                visibility = Status.Visibility.Unlisted,
+                language = "en",
+                scheduledAt = "2023-12-31T12:34:56.789Z"
+            ).execute()
+        }
+    }
+
+    @Test
+    fun schedulePoll() {
+        val client = MockClient.mock("scheduled_status_with_poll.json")
+        val statusMethods = StatusMethods(client)
+        val scheduledStatus = statusMethods.schedulePoll(
+            status = "a",
+            pollOptions = listOf("foo", "bar", "baz"),
+            pollExpiresIn = 3600,
+            pollMultiple = true,
+            pollHideTotals = false,
+            inReplyToId = null,
+            sensitive = false,
+            spoilerText = null,
+            visibility = Status.Visibility.Unlisted,
+            language = "en",
+            scheduledAt = "2023-12-31T12:34:56.789Z"
+        ).execute()
+        scheduledStatus.id shouldBeEqualTo "12345"
+        scheduledStatus.params.poll?.options?.get(0) shouldBeEqualTo "foo"
+        scheduledStatus.params.poll?.options?.get(1) shouldBeEqualTo "bar"
+        scheduledStatus.params.poll?.multiple shouldBeEqualTo true
+    }
+
+    @Test
+    fun schedulePollWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.schedulePoll(
+                status = "a",
+                pollOptions = listOf("foo", "bar", "baz"),
+                pollExpiresIn = 3600,
+                pollMultiple = true,
+                pollHideTotals = false,
+                inReplyToId = null,
+                sensitive = false,
+                spoilerText = null,
+                visibility = Status.Visibility.Unlisted,
+                language = "en",
+                scheduledAt = "2023-12-31T12:34:56.789Z"
+            ).execute()
         }
     }
 
@@ -124,7 +264,7 @@ class StatusMethodsTest {
     fun reblogStatus() {
         val client = MockClient.mock("status.json")
         val statusMethods = StatusMethods(client)
-        val status = statusMethods.reblogStatus("1").execute()
+        val status = statusMethods.reblogStatus("1", visibility = Status.Visibility.Unlisted).execute()
         status.id shouldBeEqualTo "11111"
     }
 
@@ -134,6 +274,24 @@ class StatusMethodsTest {
             val client = MockClient.ioException()
             val statusMethods = StatusMethods(client)
             statusMethods.reblogStatus("1").execute()
+        }
+    }
+
+    @Test
+    fun deleteStatus() {
+        val client = MockClient.mock("status_after_deleting.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.deleteStatus("statusId").execute()
+        status.text shouldBeEqualTo "status text after deletion"
+        status.mediaAttachments[0].id shouldBeEqualTo "22345792"
+    }
+
+    @Test
+    fun deleteStatusWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.deleteStatus("1").execute()
         }
     }
 
@@ -185,6 +343,108 @@ class StatusMethodsTest {
             val client = MockClient.ioException()
             val statusMethods = StatusMethods(client)
             statusMethods.unfavouriteStatus("1").execute()
+        }
+    }
+
+    @Test
+    fun bookmarkStatus() {
+        val client = MockClient.mock("status.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.bookmarkStatus("1").execute()
+        status.id shouldBeEqualTo "11111"
+    }
+
+    @Test
+    fun bookmarkStatusWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.bookmarkStatus("1").execute()
+        }
+    }
+
+    @Test
+    fun unbookmarkStatus() {
+        val client = MockClient.mock("status.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.unbookmarkStatus("1").execute()
+        status.id shouldBeEqualTo "11111"
+    }
+
+    @Test
+    fun unbookmarkStatusWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.unbookmarkStatus("1").execute()
+        }
+    }
+
+    @Test
+    fun muteConversation() {
+        val client = MockClient.mock("status.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.muteConversation("1").execute()
+        status.id shouldBeEqualTo "11111"
+    }
+
+    @Test
+    fun muteConversationWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.muteConversation("1").execute()
+        }
+    }
+
+    @Test
+    fun unmuteConversation() {
+        val client = MockClient.mock("status.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.unmuteConversation("1").execute()
+        status.id shouldBeEqualTo "11111"
+    }
+
+    @Test
+    fun unmuteConversationWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.unmuteConversation("1").execute()
+        }
+    }
+
+    @Test
+    fun pinStatus() {
+        val client = MockClient.mock("status.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.pinStatus("1").execute()
+        status.id shouldBeEqualTo "11111"
+    }
+
+    @Test
+    fun pinStatusWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.pinStatus("1").execute()
+        }
+    }
+
+    @Test
+    fun unpinStatus() {
+        val client = MockClient.mock("status.json")
+        val statusMethods = StatusMethods(client)
+        val status = statusMethods.unpinStatus("1").execute()
+        status.id shouldBeEqualTo "11111"
+    }
+
+    @Test
+    fun unpinStatusWithException() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val statusMethods = StatusMethods(client)
+            statusMethods.unpinStatus("1").execute()
         }
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
@@ -40,6 +40,7 @@ object MockClient {
             }
             .build()
 
+        every { clientMock.delete(ofType<String>()) } returns response
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
@@ -61,6 +62,7 @@ object MockClient {
             .body(responseBodyMock)
             .build()
 
+        every { clientMock.delete(ofType<String>()) } returns response
         every { clientMock.get(ofType<String>(), isNull(inverse = false)) } returns response
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response

--- a/sample-java/src/main/java/social/bigbone/sample/PostStatusWithMediaAttached.java
+++ b/sample-java/src/main/java/social/bigbone/sample/PostStatusWithMediaAttached.java
@@ -34,6 +34,7 @@ public class PostStatusWithMediaAttached {
         final boolean sensitive = false;
         final String spoilerText = "A castle";
         final Visibility visibility = Visibility.Private;
-        client.statuses().postStatus(statusText, inReplyToId, mediaIds, sensitive, spoilerText, visibility).execute();
+        final String language = "en";
+        client.statuses().postStatus(statusText, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language).execute();
     }
 }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/PostStatusWithMediaAttached.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/PostStatusWithMediaAttached.kt
@@ -30,6 +30,7 @@ object PostStatusWithMediaAttached {
         val sensitive = false
         val spoilerText = "A castle"
         val visibility = Status.Visibility.Private
-        client.statuses.postStatus(statusText, inReplyToId, mediaIds, sensitive, spoilerText, visibility).execute()
+        val language = "en"
+        client.statuses.postStatus(statusText, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language).execute()
     }
 }


### PR DESCRIPTION
- adds: translating, bookmarking, muting, pinning
- postStatus now has language parameter
- deleteStatus now returns a Status for subsequent editing
- reblogStatus now has visibility parameter
- implements posting of poll statuses
- implements status scheduling
- removes getCard (removed in Mastodon 3.0.0 after deprecation in 2.6.0)
- adds entities Poll, ScheduledStatus, Translation
- makes all new methods available via Rx
- includes tests and test assets for all new methods
- does not implement status editing (see #124)

Closes #125.