### PR TITLE
Close response body if response is not successful (#123)

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -262,6 +262,7 @@ private constructor(
             Method.PATCH -> patch(endpoint, null)
             Method.POST -> post(endpoint)
         }
+        response.close()
         if (!response.isSuccessful) {
             throw BigBoneRequestException(response)
         }
@@ -443,14 +444,42 @@ private constructor(
             }
         }
 
-        internal fun v2InstanceRequest(): Response {
-            val client = OkHttpClient.Builder().build()
-            return client.newCall(Request.Builder().url(fullUrl(instanceName, "api/v2/instance")).get().build()).execute()
-        }
+        /**
+         * Returns the server response for an instance request of version 2.
+         * @return server response for this request; if the response is not successful, its body will be closed
+         */
+        internal fun v2InstanceRequest(): Response = versionedInstanceRequest(2)
 
-        internal fun v1InstanceRequest(): Response {
+        /**
+         * Returns the server response for an instance request of version 1.
+         * @return server response for this request; if the response is not successful, its body will be closed
+         */
+        internal fun v1InstanceRequest(): Response = versionedInstanceRequest(1)
+
+        /**
+         * Returns the server response for an instance request of a specific version.
+         * @param version value corresponding to the version that should be returned; falls
+         *  back to returning version 1 for illegal values.
+         * @return server response for this request; if the response is not successful, its body will be closed
+         */
+        private fun versionedInstanceRequest(version: Int): Response {
+            val versionString = if (version == 2) {
+                "v2"
+            } else {
+                "v1"
+            }
             val client = OkHttpClient.Builder().build()
-            return client.newCall(Request.Builder().url(fullUrl(instanceName, "api/v1/instance")).get().build()).execute()
+            val response = client.newCall(
+                Request.Builder().url(
+                    fullUrl(
+                        instanceName,
+                        "api/$versionString/instance"
+                    )
+                ).get().build()).execute()
+            if (!response.isSuccessful) {
+                response.close()
+            }
+            return response
         }
 
         fun build(): MastodonClient {

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
@@ -74,6 +74,7 @@ class MastodonRequest<T>(
                 throw BigBoneRequestException("Successful response could not be parsed", e)
             }
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }


### PR DESCRIPTION
Response bodies need to be closed even if the response is considered not successful. See #123 for additional information.