### PR TITLE
improve method signatures for JvmOverloads

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
@@ -51,7 +51,8 @@ class RxAccountMethods(client: MastodonClient) {
         }
     }
 
-    fun getFollowers(accountId: String, range: Range): Single<Pageable<Account>> {
+    @JvmOverloads
+    fun getFollowers(accountId: String, range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {
                 val followers = accountMethods.getFollowers(accountId, range).execute()
@@ -62,7 +63,8 @@ class RxAccountMethods(client: MastodonClient) {
         }
     }
 
-    fun getFollowing(accountId: String, range: Range): Single<Pageable<Account>> {
+    @JvmOverloads
+    fun getFollowing(accountId: String, range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {
                 val following = accountMethods.getFollowing(accountId, range).execute()
@@ -73,10 +75,17 @@ class RxAccountMethods(client: MastodonClient) {
         }
     }
 
-    fun getStatuses(accountId: String, onlyMedia: Boolean, range: Range): Single<Pageable<Status>> {
+    @JvmOverloads
+    fun getStatuses(
+        accountId: String,
+        onlyMedia: Boolean = false,
+        excludeReplies: Boolean = false,
+        pinned: Boolean = false,
+        range: Range = Range()
+    ): Single<Pageable<Status>> {
         return Single.create {
             try {
-                val statuses = accountMethods.getStatuses(accountId, onlyMedia, range = range).execute()
+                val statuses = accountMethods.getStatuses(accountId, onlyMedia, excludeReplies, pinned, range).execute()
                 it.onSuccess(statuses)
             } catch (throwable: Throwable) {
                 it.onErrorIfNotDisposed(throwable)
@@ -161,6 +170,7 @@ class RxAccountMethods(client: MastodonClient) {
         }
     }
 
+    @JvmOverloads
     fun searchAccounts(query: String, limit: Int = 40): Single<List<Account>> {
         return Single.create {
             try {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
@@ -15,10 +15,11 @@ import social.bigbone.rx.extensions.onErrorIfNotDisposed
 class RxAppMethods(client: MastodonClient) {
     private val appMethods = AppMethods(client)
 
+    @JvmOverloads
     fun createApp(
         clientName: String,
         redirectUris: String = "urn:ietf:wg:oauth:2.0:oob",
-        scope: Scope,
+        scope: Scope = Scope(Scope.Name.ALL),
         website: String? = null
     ): Single<Application> {
         return Single.create {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxBlockMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxBlockMethods.kt
@@ -16,6 +16,7 @@ import social.bigbone.rx.extensions.onErrorIfNotDisposed
 class RxBlockMethods(client: MastodonClient) {
     private val blockMethods = BlockMethods(client)
 
+    @JvmOverloads
     fun getBlocks(range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxFavouriteMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxFavouriteMethods.kt
@@ -16,6 +16,7 @@ import social.bigbone.rx.extensions.onErrorIfNotDisposed
 class RxFavouriteMethods(client: MastodonClient) {
     private val favouriteMethods = FavouriteMethods(client)
 
+    @JvmOverloads
     fun getFavourites(range: Range = Range()): Single<Pageable<Status>> {
         return Single.create {
             try {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxFollowRequestMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxFollowRequestMethods.kt
@@ -17,6 +17,7 @@ import social.bigbone.rx.extensions.onErrorIfNotDisposed
 class RxFollowRequestMethods(client: MastodonClient) {
     private val followRequestMethods = FollowRequestMethods(client)
 
+    @JvmOverloads
     fun getFollowRequests(range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxMuteMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxMuteMethods.kt
@@ -15,6 +15,7 @@ import social.bigbone.api.method.MuteMethods
 class RxMuteMethods(client: MastodonClient) {
     private val muteMethods = MuteMethods(client)
 
+    @JvmOverloads
     fun getMutes(range: Range = Range()): Single<Pageable<Account>> {
         return Single.create {
             try {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxNotificationMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxNotificationMethods.kt
@@ -16,10 +16,14 @@ import social.bigbone.api.method.NotificationMethods
 class RxNotificationMethods(client: MastodonClient) {
     private val notificationMethods = NotificationMethods(client)
 
-    fun getNotifications(range: Range): Single<Pageable<Notification>> {
+    @JvmOverloads
+    fun getNotifications(
+        excludeTypes: List<Notification.Type>? = null,
+        range: Range = Range()
+    ): Single<Pageable<Notification>> {
         return Single.create {
             try {
-                val notifications = notificationMethods.getNotifications(range)
+                val notifications = notificationMethods.getNotifications(excludeTypes, range)
                 it.onSuccess(notifications.execute())
             } catch (e: Throwable) {
                 it.onError(e)

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxSearchMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxSearchMethods.kt
@@ -13,7 +13,8 @@ import social.bigbone.api.method.SearchMethods
 class RxSearchMethods(client: MastodonClient) {
     private val searchMethodsMethod = SearchMethods(client)
 
-    fun searchContent(query: String, resolve: Boolean = true): Single<Search> {
+    @JvmOverloads
+    fun searchContent(query: String, resolve: Boolean = false): Single<Search> {
         return Single.create {
             try {
                 val results = searchMethodsMethod.searchContent(query, resolve)

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxStatusMethods.kt
@@ -80,16 +80,16 @@ class RxStatusMethods(client: MastodonClient) {
     @JvmOverloads
     fun postStatus(
         status: String,
+        visibility: Status.Visibility = Status.Visibility.Public,
         inReplyToId: String? = null,
         mediaIds: List<String>? = null,
         sensitive: Boolean = false,
         spoilerText: String? = null,
-        visibility: Status.Visibility = Status.Visibility.Public,
         language: String? = null
     ): Single<Status> {
         return Single.create {
             try {
-                val result = statusMethods.postStatus(status, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language)
+                val result = statusMethods.postStatus(status, visibility, inReplyToId, mediaIds, sensitive, spoilerText, language)
                 it.onSuccess(result.execute())
             } catch (e: Throwable) {
                 it.onError(e)
@@ -102,12 +102,12 @@ class RxStatusMethods(client: MastodonClient) {
         status: String,
         pollOptions: List<String>,
         pollExpiresIn: Int,
+        visibility: Status.Visibility = Status.Visibility.Public,
         pollMultiple: Boolean = false,
         pollHideTotals: Boolean = false,
         inReplyToId: String? = null,
         sensitive: Boolean = false,
         spoilerText: String? = null,
-        visibility: Status.Visibility = Status.Visibility.Public,
         language: String? = null
     ): Single<Status> {
         return Single.create {
@@ -116,12 +116,12 @@ class RxStatusMethods(client: MastodonClient) {
                     status,
                     pollOptions,
                     pollExpiresIn,
+                    visibility,
                     pollMultiple,
                     pollHideTotals,
                     inReplyToId,
                     sensitive,
                     spoilerText,
-                    visibility,
                     language
                 )
                 it.onSuccess(result.execute())
@@ -134,17 +134,17 @@ class RxStatusMethods(client: MastodonClient) {
     @JvmOverloads
     fun scheduleStatus(
         status: String,
+        scheduledAt: String,
+        visibility: Status.Visibility = Status.Visibility.Public,
         inReplyToId: String? = null,
         mediaIds: List<String>? = null,
         sensitive: Boolean = false,
         spoilerText: String? = null,
-        visibility: Status.Visibility = Status.Visibility.Public,
-        language: String? = null,
-        scheduledAt: String
+        language: String? = null
     ): Single<ScheduledStatus> {
         return Single.create {
             try {
-                val result = statusMethods.scheduleStatus(status, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language, scheduledAt)
+                val result = statusMethods.scheduleStatus(status, scheduledAt, visibility, inReplyToId, mediaIds, sensitive, spoilerText, language)
                 it.onSuccess(result.execute())
             } catch (e: Throwable) {
                 it.onError(e)
@@ -155,31 +155,31 @@ class RxStatusMethods(client: MastodonClient) {
     @JvmOverloads
     fun schedulePoll(
         status: String,
+        scheduledAt: String,
         pollOptions: List<String>,
         pollExpiresIn: Int,
+        visibility: Status.Visibility = Status.Visibility.Public,
         pollMultiple: Boolean = false,
         pollHideTotals: Boolean = false,
         inReplyToId: String? = null,
         sensitive: Boolean = false,
         spoilerText: String? = null,
-        visibility: Status.Visibility = Status.Visibility.Public,
-        language: String? = null,
-        scheduledAt: String
+        language: String? = null
     ): Single<ScheduledStatus> {
         return Single.create {
             try {
                 val result = statusMethods.schedulePoll(
                     status,
+                    scheduledAt,
                     pollOptions,
                     pollExpiresIn,
+                    visibility,
                     pollMultiple,
                     pollHideTotals,
                     inReplyToId,
                     sensitive,
                     spoilerText,
-                    visibility,
-                    language,
-                    scheduledAt
+                    language
                 )
                 it.onSuccess(result.execute())
             } catch (e: Throwable) {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxTimelineMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxTimelineMethods.kt
@@ -16,28 +16,31 @@ import social.bigbone.rx.extensions.single
 class RxTimelineMethods(client: MastodonClient) {
     private val timelineMethods = TimelineMethods(client)
 
+    @JvmOverloads
     fun getHomeTimeline(range: Range = Range()): Single<Pageable<Status>> {
         return single {
             timelineMethods.getHomeTimeline(range).execute()
         }
     }
 
+    @JvmOverloads
     fun getPublicTimeline(
-        range: Range = Range(),
-        statusOrigin: TimelineMethods.StatusOrigin = TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE
+        statusOrigin: TimelineMethods.StatusOrigin = TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE,
+        range: Range = Range()
     ): Single<Pageable<Status>> {
         return single {
-            timelineMethods.getPublicTimeline(range, statusOrigin).execute()
+            timelineMethods.getPublicTimeline(statusOrigin, range).execute()
         }
     }
 
+    @JvmOverloads
     fun getTagTimeline(
         tag: String,
-        range: Range = Range(),
-        statusOrigin: TimelineMethods.StatusOrigin = TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE
+        statusOrigin: TimelineMethods.StatusOrigin = TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE,
+        range: Range = Range()
     ): Single<Pageable<Status>> {
         return single {
-            timelineMethods.getTagTimeline(tag, range, statusOrigin).execute()
+            timelineMethods.getTagTimeline(tag, statusOrigin, range).execute()
         }
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/NotificationMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/NotificationMethods.kt
@@ -15,12 +15,12 @@ class NotificationMethods(private val client: MastodonClient) {
 
     /**
      * Notifications concerning the user.
-     * @param range optional Range for the pageable return value
      * @param excludeTypes Types to exclude from the results. See Mastodon API documentation for details.
+     * @param range optional Range for the pageable return value
      * @see <a href="https://docs.joinmastodon.org/methods/notifications/#get">Mastodon API documentation: methods/notifications/#get</a>
      */
     @JvmOverloads
-    fun getNotifications(range: Range = Range(), excludeTypes: List<Notification.Type>? = null): MastodonRequest<Pageable<Notification>> {
+    fun getNotifications(excludeTypes: List<Notification.Type>? = null, range: Range = Range()): MastodonRequest<Pageable<Notification>> {
         return client.getPageableMastodonRequest(
             endpoint = "api/v1/notifications",
             method = MastodonClient.Method.GET,

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
@@ -98,11 +98,11 @@ class StatusMethods(private val client: MastodonClient) {
      * Publish a status with the given parameters. To publish a status containing a poll, use [postPoll].
      * To schedule a status, use [scheduleStatus].
      * @param status the text of the status
+     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param inReplyToId the local id of the status you want to reply to
      * @param mediaIds the array of media ids to attach to the status (maximum 4)
      * @param sensitive set this to mark the media of the status as NSFW
      * @param spoilerText text to be shown as a warning before the actual content
-     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param language ISO 639 language code for this status.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
      */
@@ -110,23 +110,23 @@ class StatusMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun postStatus(
         status: String,
-        inReplyToId: String?,
-        mediaIds: List<String>?,
-        sensitive: Boolean,
-        spoilerText: String?,
         visibility: Status.Visibility = Status.Visibility.Public,
-        language: String?
+        inReplyToId: String? = null,
+        mediaIds: List<String>? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        language: String? = null
     ): MastodonRequest<Status> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("status", status)
+                append("visibility", visibility.value)
                 inReplyToId?.let { append("in_reply_to_id", it) }
                 mediaIds?.let { append("media_ids", it) }
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
-                append("visibility", visibility.value)
                 language?.let { append("language", it) }
             }
         )
@@ -137,12 +137,12 @@ class StatusMethods(private val client: MastodonClient) {
      * @param status the text of the status
      * @param pollOptions Possible answers to the poll.
      * @param pollExpiresIn Duration that the poll should be open, in seconds.
+     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param pollMultiple Allow multiple choices? Defaults to false.
      * @param pollHideTotals Hide vote counts until the poll ends? Defaults to false.
      * @param inReplyToId the local id of the status you want to reply to
      * @param sensitive set this to mark the media of the status as NSFW
      * @param spoilerText text to be shown as a warning before the actual content
-     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param language ISO 639 language code for this status.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
      */
@@ -152,13 +152,13 @@ class StatusMethods(private val client: MastodonClient) {
         status: String,
         pollOptions: List<String>,
         pollExpiresIn: Int,
+        visibility: Status.Visibility = Status.Visibility.Public,
         pollMultiple: Boolean = false,
         pollHideTotals: Boolean = false,
-        inReplyToId: String?,
-        sensitive: Boolean,
-        spoilerText: String?,
-        visibility: Status.Visibility = Status.Visibility.Public,
-        language: String?
+        inReplyToId: String? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        language: String? = null
     ): MastodonRequest<Status> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses",
@@ -167,12 +167,12 @@ class StatusMethods(private val client: MastodonClient) {
                 append("status", status)
                 append("poll[options]", pollOptions)
                 append("poll[expires_in]", pollExpiresIn)
+                append("visibility", visibility.value)
                 append("poll[multiple]", pollMultiple)
                 append("poll[hide_totals", pollHideTotals)
                 inReplyToId?.let { append("in_reply_to_id", it) }
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
-                append("visibility", visibility.value)
                 language?.let { append("language", it) }
             }
         )
@@ -182,39 +182,39 @@ class StatusMethods(private val client: MastodonClient) {
      * Schedule a status with the given parameters. To schedule a status containing a poll, use [schedulePoll].
      * To post a status immediately, use [postStatus].
      * @param status the text of the status
+     * @param scheduledAt ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.
+     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param inReplyToId the local id of the status you want to reply to
      * @param mediaIds the array of media ids to attach to the status (maximum 4)
      * @param sensitive set this to mark the media of the status as NSFW
      * @param spoilerText text to be shown as a warning before the actual content
-     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param language ISO 639 language code for this status.
-     * @param scheduledAt ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
      */
     @JvmOverloads
     @Throws(BigBoneRequestException::class)
     fun scheduleStatus(
         status: String,
-        inReplyToId: String?,
-        mediaIds: List<String>?,
-        sensitive: Boolean,
-        spoilerText: String?,
+        scheduledAt: String,
         visibility: Status.Visibility = Status.Visibility.Public,
-        language: String?,
-        scheduledAt: String
+        inReplyToId: String? = null,
+        mediaIds: List<String>? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        language: String? = null
     ): MastodonRequest<ScheduledStatus> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("status", status)
+                append("scheduled_at", scheduledAt)
+                append("visibility", visibility.value)
                 inReplyToId?.let { append("in_reply_to_id", it) }
                 mediaIds?.let { append("media_ids", it) }
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
-                append("visibility", visibility.value)
                 language?.let { append("language", it) }
-                append("scheduled_at", scheduledAt)
             }
         )
     }
@@ -222,48 +222,48 @@ class StatusMethods(private val client: MastodonClient) {
     /**
      * Schedule a status containing a poll with the given parameters. To post immediately, use [postPoll].
      * @param status the text of the status
+     * @param scheduledAt ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.
      * @param pollOptions Possible answers to the poll.
      * @param pollExpiresIn Duration that the poll should be open, in seconds.
+     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param pollMultiple Allow multiple choices? Defaults to false.
      * @param pollHideTotals Hide vote counts until the poll ends? Defaults to false.
      * @param inReplyToId the local id of the status you want to reply to
      * @param sensitive set this to mark the media of the status as NSFW
      * @param spoilerText text to be shown as a warning before the actual content
-     * @param visibility either "direct", "private", "unlisted" or "public"
      * @param language ISO 639 language code for this status.
-     * @param scheduledAt ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.
      * @see <a href="https://docs.joinmastodon.org/methods/statuses/#create">Mastodon API documentation: methods/statuses/#create</a>
      */
     @JvmOverloads
     @Throws(BigBoneRequestException::class)
     fun schedulePoll(
         status: String,
+        scheduledAt: String,
         pollOptions: List<String>,
         pollExpiresIn: Int,
+        visibility: Status.Visibility = Status.Visibility.Public,
         pollMultiple: Boolean = false,
         pollHideTotals: Boolean = false,
-        inReplyToId: String?,
-        sensitive: Boolean,
-        spoilerText: String?,
-        visibility: Status.Visibility = Status.Visibility.Public,
-        language: String?,
-        scheduledAt: String
+        inReplyToId: String? = null,
+        sensitive: Boolean = false,
+        spoilerText: String? = null,
+        language: String? = null
     ): MastodonRequest<ScheduledStatus> {
         return client.getMastodonRequest(
             endpoint = "api/v1/statuses",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("status", status)
+                append("scheduled_at", scheduledAt)
                 append("poll[options]", pollOptions)
                 append("poll[expires_in]", pollExpiresIn)
+                append("visibility", visibility.value)
                 append("poll[multiple]", pollMultiple)
                 append("poll[hide_totals]", pollHideTotals)
                 inReplyToId?.let { append("in_reply_to_id", it) }
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
-                append("visibility", visibility.value)
                 language?.let { append("language", it) }
-                append("scheduled_at", scheduledAt)
             }
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/TimelineMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/TimelineMethods.kt
@@ -42,6 +42,7 @@ class TimelineMethods(private val client: MastodonClient) {
      * @param range restrict result to a specific range
      * @see <a href="https://docs.joinmastodon.org/methods/timelines/#list">Mastodon API documentation: methods/timelines/#list</a>
      */
+    @JvmOverloads
     @Throws(BigBoneRequestException::class)
     fun getListTimeline(listID: String, range: Range = Range()): MastodonRequest<Pageable<Status>> {
         return client.getPageableMastodonRequest(
@@ -54,14 +55,14 @@ class TimelineMethods(private val client: MastodonClient) {
     /**
      * Get the public timeline of the configured instance. Defaults to a combination of local and remote statuses,
      * but can be restricted to either.
-     * @param range restrict result to a specific range
      * @param statusOrigin optionally restrict result to either local or remote (=federated) statuses; defaults to all
+     * @param range restrict result to a specific range
      * @see <a href="https://docs.joinmastodon.org/methods/timelines/#public">Mastodon API documentation: methods/timelines/#public</a>
      */
     @JvmOverloads
     fun getPublicTimeline(
-        range: Range = Range(),
-        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE
+        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE,
+        range: Range = Range()
     ): MastodonRequest<Pageable<Status>> {
         return client.getPageableMastodonRequest(
             endpoint = "api/v1/timelines/public",
@@ -80,15 +81,15 @@ class TimelineMethods(private val client: MastodonClient) {
      * Get the public timeline for a specific hashtag of the configured instance.
      * Defaults to a combination of local and remote (=federated) statuses, but can be restricted to either.
      * @param tag the hashtag for which a timeline should be returned
-     * @param range restrict result to a specific range
      * @param statusOrigin optionally restrict result to either local or remote statuses; defaults to all
+     * @param range restrict result to a specific range
      * @see <a href="https://docs.joinmastodon.org/methods/timelines/#tag">Mastodon API documentation: methods/timelines/#tag</a>
      */
     @JvmOverloads
     fun getTagTimeline(
         tag: String,
-        range: Range = Range(),
-        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE
+        statusOrigin: StatusOrigin = StatusOrigin.LOCAL_AND_REMOTE,
+        range: Range = Range()
     ): MastodonRequest<Pageable<Status>> {
         return client.getPageableMastodonRequest(
             endpoint = "api/v1/timelines/tag/$tag",

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/StatusMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/StatusMethodsTest.kt
@@ -108,11 +108,11 @@ class StatusMethodsTest {
         val statusMethods = StatusMethods(client)
         val status = statusMethods.postStatus(
             status = "a",
+            visibility = Status.Visibility.Unlisted,
             inReplyToId = null,
             mediaIds = null,
             sensitive = false,
             spoilerText = null,
-            visibility = Status.Visibility.Unlisted,
             language = "en"
         ).execute()
         status.id shouldBeEqualTo "11111"
@@ -125,11 +125,11 @@ class StatusMethodsTest {
             val statusMethods = StatusMethods(client)
             statusMethods.postStatus(
                 status = "a",
+                visibility = Status.Visibility.Unlisted,
                 inReplyToId = null,
                 mediaIds = null,
                 sensitive = false,
                 spoilerText = null,
-                visibility = Status.Visibility.Unlisted,
                 language = "en"
             ).execute()
         }
@@ -144,11 +144,6 @@ class StatusMethodsTest {
             status = "a",
             pollOptions = pollOptions,
             pollExpiresIn = 3600,
-            pollMultiple = false,
-            pollHideTotals = false,
-            inReplyToId = null,
-            sensitive = false,
-            spoilerText = null,
             visibility = Status.Visibility.Unlisted,
             language = "en"
         ).execute()
@@ -168,11 +163,6 @@ class StatusMethodsTest {
                 status = "a",
                 pollOptions = pollOptions,
                 pollExpiresIn = 3600,
-                pollMultiple = false,
-                pollHideTotals = false,
-                inReplyToId = null,
-                sensitive = false,
-                spoilerText = null,
                 visibility = Status.Visibility.Unlisted,
                 language = "en"
             ).execute()
@@ -185,13 +175,13 @@ class StatusMethodsTest {
         val statusMethods = StatusMethods(client)
         val scheduledStatus = statusMethods.scheduleStatus(
             status = "a",
+            scheduledAt = "2023-12-31T12:34:56.789Z",
+            visibility = Status.Visibility.Unlisted,
             inReplyToId = null,
             mediaIds = null,
             sensitive = false,
             spoilerText = null,
-            visibility = Status.Visibility.Unlisted,
-            language = "en",
-            scheduledAt = "2023-12-31T12:34:56.789Z"
+            language = "en"
         ).execute()
         scheduledStatus.id shouldBeEqualTo "12345"
         scheduledStatus.scheduledAt shouldBeEqualTo "2023-12-31T12:34:56.789Z"
@@ -205,13 +195,13 @@ class StatusMethodsTest {
             val statusMethods = StatusMethods(client)
             statusMethods.scheduleStatus(
                 status = "a",
+                scheduledAt = "2023-12-31T12:34:56.789Z",
+                visibility = Status.Visibility.Unlisted,
                 inReplyToId = null,
                 mediaIds = null,
                 sensitive = false,
                 spoilerText = null,
-                visibility = Status.Visibility.Unlisted,
                 language = "en",
-                scheduledAt = "2023-12-31T12:34:56.789Z"
             ).execute()
         }
     }
@@ -222,16 +212,16 @@ class StatusMethodsTest {
         val statusMethods = StatusMethods(client)
         val scheduledStatus = statusMethods.schedulePoll(
             status = "a",
+            scheduledAt = "2023-12-31T12:34:56.789Z",
             pollOptions = listOf("foo", "bar", "baz"),
             pollExpiresIn = 3600,
+            visibility = Status.Visibility.Unlisted,
             pollMultiple = true,
             pollHideTotals = false,
             inReplyToId = null,
             sensitive = false,
             spoilerText = null,
-            visibility = Status.Visibility.Unlisted,
-            language = "en",
-            scheduledAt = "2023-12-31T12:34:56.789Z"
+            language = "en"
         ).execute()
         scheduledStatus.id shouldBeEqualTo "12345"
         scheduledStatus.params.poll?.options?.get(0) shouldBeEqualTo "foo"
@@ -246,16 +236,16 @@ class StatusMethodsTest {
             val statusMethods = StatusMethods(client)
             statusMethods.schedulePoll(
                 status = "a",
+                scheduledAt = "2023-12-31T12:34:56.789Z",
                 pollOptions = listOf("foo", "bar", "baz"),
                 pollExpiresIn = 3600,
+                visibility = Status.Visibility.Unlisted,
                 pollMultiple = true,
                 pollHideTotals = false,
                 inReplyToId = null,
                 sensitive = false,
                 spoilerText = null,
-                visibility = Status.Visibility.Unlisted,
-                language = "en",
-                scheduledAt = "2023-12-31T12:34:56.789Z"
+                language = "en"
             ).execute()
         }
     }

--- a/sample-java/src/main/java/social/bigbone/sample/GetPublicTimeline.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetPublicTimeline.java
@@ -2,7 +2,6 @@ package social.bigbone.sample;
 
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Pageable;
-import social.bigbone.api.Range;
 import social.bigbone.api.entity.Status;
 import social.bigbone.api.exception.BigBoneRequestException;
 
@@ -18,7 +17,7 @@ public class GetPublicTimeline {
             .build();
 
         // Get statuses from public timeline
-        final Pageable<Status> statuses = client.timelines().getPublicTimeline(new Range(), LOCAL_AND_REMOTE).execute();
+        final Pageable<Status> statuses = client.timelines().getPublicTimeline(LOCAL_AND_REMOTE).execute();
         statuses.getPart().forEach(status -> System.out.println(status.getContent()));
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/GetRawJson.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetRawJson.java
@@ -1,7 +1,6 @@
 package social.bigbone.sample;
 
 import social.bigbone.MastodonClient;
-import social.bigbone.api.Range;
 import social.bigbone.api.exception.BigBoneRequestException;
 
 import static social.bigbone.api.method.TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE;
@@ -16,7 +15,7 @@ public class GetRawJson {
             .build();
 
         // Print timeline statuses
-        client.timelines().getPublicTimeline(new Range(), LOCAL_AND_REMOTE).doOnJson(
+        client.timelines().getPublicTimeline(LOCAL_AND_REMOTE).doOnJson(
             System.out::println
         ).execute();
     }

--- a/sample-java/src/main/java/social/bigbone/sample/GetTagTimeline.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetTagTimeline.java
@@ -2,7 +2,6 @@ package social.bigbone.sample;
 
 import social.bigbone.MastodonClient;
 import social.bigbone.api.Pageable;
-import social.bigbone.api.Range;
 import social.bigbone.api.entity.Status;
 import social.bigbone.api.exception.BigBoneRequestException;
 
@@ -19,7 +18,7 @@ public class GetTagTimeline {
             .build();
 
         // Get statuses from public timeline
-        final Pageable<Status> statuses = client.timelines().getTagTimeline(hashtag, new Range(), LOCAL_AND_REMOTE).execute();
+        final Pageable<Status> statuses = client.timelines().getTagTimeline(hashtag, LOCAL_AND_REMOTE).execute();
         statuses.getPart().forEach(status -> System.out.println(status.getContent()));
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/PostStatusWithMediaAttached.java
+++ b/sample-java/src/main/java/social/bigbone/sample/PostStatusWithMediaAttached.java
@@ -35,6 +35,6 @@ public class PostStatusWithMediaAttached {
         final String spoilerText = "A castle";
         final Visibility visibility = Visibility.Private;
         final String language = "en";
-        client.statuses().postStatus(statusText, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language).execute();
+        client.statuses().postStatus(statusText, visibility, inReplyToId, mediaIds, sensitive, spoilerText, language).execute();
     }
 }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetPublicTimeline.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetPublicTimeline.kt
@@ -1,7 +1,6 @@
 package social.bigbone.sample
 
 import social.bigbone.MastodonClient
-import social.bigbone.api.Range
 import social.bigbone.api.method.TimelineMethods.StatusOrigin
 
 object GetPublicTimeline {
@@ -14,7 +13,7 @@ object GetPublicTimeline {
             .build()
 
         // Get statuses from public timeline
-        val statuses = client.timelines.getPublicTimeline(Range(), StatusOrigin.LOCAL_AND_REMOTE).execute()
+        val statuses = client.timelines.getPublicTimeline(StatusOrigin.LOCAL_AND_REMOTE).execute()
         statuses.part.forEach {
             println(it.content)
         }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetTagTimeline.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetTagTimeline.kt
@@ -1,7 +1,6 @@
 package social.bigbone.sample
 
 import social.bigbone.MastodonClient
-import social.bigbone.api.Range
 import social.bigbone.api.method.TimelineMethods
 
 object GetTagTimeline {
@@ -15,7 +14,7 @@ object GetTagTimeline {
             .build()
 
         // Get statuses from public timeline
-        val statuses = client.timelines.getTagTimeline(hashtag, Range(), TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE).execute()
+        val statuses = client.timelines.getTagTimeline(hashtag, TimelineMethods.StatusOrigin.LOCAL_AND_REMOTE).execute()
         statuses.part.forEach {
             println(it.content)
         }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/PostStatusWithMediaAttached.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/PostStatusWithMediaAttached.kt
@@ -25,12 +25,12 @@ object PostStatusWithMediaAttached {
 
         // Post status with media attached
         val statusText = "Status posting test"
+        val visibility = Status.Visibility.Private
         val inReplyToId: String? = null
         val mediaIds = listOf(mediaId)
         val sensitive = false
         val spoilerText = "A castle"
-        val visibility = Status.Visibility.Private
         val language = "en"
-        client.statuses.postStatus(statusText, inReplyToId, mediaIds, sensitive, spoilerText, visibility, language).execute()
+        client.statuses.postStatus(statusText, visibility, inReplyToId, mediaIds, sensitive, spoilerText, language).execute()
     }
 }


### PR DESCRIPTION
- adds default values for optional parameters where possible
- sorts method parameters: mandatory first, then optional in increasing likelihood of default value being used, technical parameters (Range) last
- additional JvmOverloads annotation for Rx where missing

Does not deal with the following:

- `AccountMethods.updateCredentials()` - unclear which of the existing parameters, if any, can have default values
- OAuthMethods - some of the methods have default parameters, but it is probably worth requiring both `scope` and `redirectUri`? At least the used default values should be checked
- StreamingMethods

Closes #152