### PR TITLE
Add focus points for smart thumbnailing

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/MediaAttachment.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/MediaAttachment.kt
@@ -1,6 +1,7 @@
 package social.bigbone.api.entity
 
 import com.google.gson.annotations.SerializedName
+import social.bigbone.api.entity.data.Focus
 
 /**
  * Represents a file or media attachment that can be added to a status.
@@ -44,6 +45,12 @@ data class MediaAttachment(
     val textUrl: String? = null,
 
     /**
+     * Metadata returned by Paperclip.
+     */
+    @SerializedName("meta")
+    val meta: Meta? = null,
+
+    /**
      * Alternate text that describes what is in the media attachment, to be used for the visually impaired or when media attachments do not load.
      */
     @SerializedName("description")
@@ -55,6 +62,17 @@ data class MediaAttachment(
     @SerializedName("blurhash")
     val blurhash: String? = null
 ) {
+    /**
+     * Metadata returned by Paperclip.
+     */
+    data class Meta(
+        /**
+         * Contains the coordinates to be used for smart thumbnail cropping.
+         */
+        @SerializedName("focus")
+        val focus: Focus? = null,
+    )
+
     /**
      * The available media types.
      */

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/data/Focus.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/data/Focus.kt
@@ -12,6 +12,6 @@ data class Focus(
 
     @SerializedName("y")
     val y: Float
-)
-
-fun Focus.asString(): String = "$x, $y"
+) {
+    override fun toString(): String = "$x, $y"
+}

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/data/Focus.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/data/Focus.kt
@@ -1,0 +1,17 @@
+package social.bigbone.api.entity.data
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Contains the coordinates to be used for smart thumbnail cropping.
+ * For more details, please have a look at https://docs.joinmastodon.org/api/guidelines/#focal-points
+ */
+data class Focus(
+    @SerializedName("x")
+    val x: Float,
+
+    @SerializedName("y")
+    val y: Float
+)
+
+fun Focus.asString():String = "$x, $y"

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/data/Focus.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/data/Focus.kt
@@ -14,4 +14,4 @@ data class Focus(
     val y: Float
 )
 
-fun Focus.asString():String = "$x, $y"
+fun Focus.asString(): String = "$x, $y"

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/MediaMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/MediaMethods.kt
@@ -7,7 +7,6 @@ import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.api.entity.MediaAttachment
 import social.bigbone.api.entity.data.Focus
-import social.bigbone.api.entity.data.asString
 import java.io.File
 
 /**
@@ -19,7 +18,7 @@ class MediaMethods(private val client: MastodonClient) {
      * Creates an attachment to be used with a new status. This method will return after the full sized media is done processing.
      * @param file the file that should be uploaded
      * @param mediaType media type of the file as a string, e.g. "image/png"
-     * @param focus Two floating points (x,y), comma-delimited, ranging from -1.0 to 1.0
+     * @param focus a [Focus] instance which specifies the x- and y- coordinate of the focal point. Valid range for x and y is -1.0 to 1.0.
      * @see <a href="https://docs.joinmastodon.org/methods/media/#v1">Mastodon API documentation: methods/media/#v1</a>
      */
     @JvmOverloads
@@ -30,7 +29,7 @@ class MediaMethods(private val client: MastodonClient) {
             .setType(MultipartBody.FORM)
             .addPart(part)
         if (focus != null) {
-            requestBodyBuilder.addFormDataPart("focus", focus.asString())
+            requestBodyBuilder.addFormDataPart("focus", focus.toString())
         }
         val requestBody = requestBodyBuilder.build()
         return MastodonRequest<MediaAttachment>(

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/MediaMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/MediaMethods.kt
@@ -6,6 +6,8 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.api.entity.MediaAttachment
+import social.bigbone.api.entity.data.Focus
+import social.bigbone.api.entity.data.asString
 import java.io.File
 
 /**
@@ -17,15 +19,20 @@ class MediaMethods(private val client: MastodonClient) {
      * Creates an attachment to be used with a new status. This method will return after the full sized media is done processing.
      * @param file the file that should be uploaded
      * @param mediaType media type of the file as a string, e.g. "image/png"
+     * @param focus Two floating points (x,y), comma-delimited, ranging from -1.0 to 1.0
      * @see <a href="https://docs.joinmastodon.org/methods/media/#v1">Mastodon API documentation: methods/media/#v1</a>
      */
-    fun uploadMedia(file: File, mediaType: String): MastodonRequest<MediaAttachment> {
+    @JvmOverloads
+    fun uploadMedia(file: File, mediaType: String, focus: Focus? = null): MastodonRequest<MediaAttachment> {
         val body = file.asRequestBody(mediaType.toMediaTypeOrNull())
         val part = MultipartBody.Part.createFormData("file", file.name, body)
-        val requestBody = MultipartBody.Builder()
+        val requestBodyBuilder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addPart(part)
-            .build()
+        if (focus != null) {
+            requestBodyBuilder.addFormDataPart("focus", focus.asString())
+        }
+        val requestBody = requestBodyBuilder.build()
         return MastodonRequest<MediaAttachment>(
             {
                 client.postRequestBody("api/v1/media", requestBody)


### PR DESCRIPTION
With this PR, we allow the user to set a focal point on a media that is uploaded using the media upload API. Also, the focal point data is returned in the entity after the call.