### PR TITLE
remove redirect URI default value from methods

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
@@ -18,7 +18,7 @@ class RxAppMethods(client: MastodonClient) {
     @JvmOverloads
     fun createApp(
         clientName: String,
-        redirectUris: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUris: String,
         scope: Scope = Scope(Scope.Name.ALL),
         website: String? = null
     ): Single<Application> {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
@@ -18,7 +18,7 @@ class RxOAuthMethods(client: MastodonClient) {
     fun getUserAccessTokenWithAuthorizationCodeGrant(
         clientId: String,
         clientSecret: String,
-        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUri: String,
         code: String
     ): Single<Token> {
         return Single.create {
@@ -35,7 +35,7 @@ class RxOAuthMethods(client: MastodonClient) {
         clientId: String,
         clientSecret: String,
         scope: Scope = Scope(Scope.Name.READ),
-        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUri: String,
         username: String,
         password: String
     ): Single<Token> {

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/TestHelpers.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/TestHelpers.kt
@@ -38,6 +38,7 @@ object TestHelpers {
         return client.oauth.getAccessTokenWithClientCredentialsGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
+            redirectUri = TestConstants.REDIRECT_URI,
             scope = Scope(Scope.Name.ALL)
         ).execute()
     }

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/v300/V300StatusMethodsIntegrationTest.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/v300/V300StatusMethodsIntegrationTest.kt
@@ -50,6 +50,7 @@ class V300StatusMethodsIntegrationTest {
         return client.oauth.getAccessTokenWithClientCredentialsGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
+            redirectUri = TestConstants.REDIRECT_URI,
             scope = Scope(Scope.Name.ALL)
         ).execute()
     }

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/v402/V402StatusMethodsIntegrationTest.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/v402/V402StatusMethodsIntegrationTest.kt
@@ -50,6 +50,7 @@ class V402StatusMethodsIntegrationTest {
         return client.oauth.getAccessTokenWithClientCredentialsGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
+            redirectUri = TestConstants.REDIRECT_URI,
             scope = Scope(Scope.Name.ALL)
         ).execute()
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
@@ -15,8 +15,7 @@ class AppMethods(private val client: MastodonClient) {
     /**
      * Create a new application to obtain OAuth2 credentials.
      * @param clientName A name for your application
-     * @param redirectUris Where the user should be redirected after authorization. Defaults to "urn:ietf:wg:oauth:2.0:oob",
-     *  which will display the authorization code to the user instead of redirecting to a web page.
+     * @param redirectUris Where the user should be redirected after authorization.
      * @param scope Space separated list of scopes. Defaults to all scopes.
      * @param website A URL to the homepage of your app, defaults to null.
      * @see <a href="https://docs.joinmastodon.org/methods/apps/#create">Mastodon apps API methods #create</a>
@@ -24,7 +23,7 @@ class AppMethods(private val client: MastodonClient) {
     @JvmOverloads
     fun createApp(
         clientName: String,
-        redirectUris: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUris: String,
         scope: Scope = Scope(Scope.Name.ALL),
         website: String? = null
     ): MastodonRequest<Application> {

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
@@ -15,17 +15,14 @@ class OAuthMethods(private val client: MastodonClient) {
     /**
      * Returns a URL that can be used to display an authorization form to the user. If approved,
      * it will create and return an authorization code, then redirect to the desired redirectUri,
-     * or show the authorization code if urn:ietf:wg:oauth:2.0:oob was requested.
+     * or show the authorization code if redirectUri is "urn:ietf:wg:oauth:2.0:oob".
      * The authorization code can be used while requesting a token to obtain access to user-level methods.
      * @param clientId The client ID, obtained during app registration.
      * @param scope List of requested OAuth scopes, separated by spaces. Must be a subset of scopes declared during app registration.
-     * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
-     *  which will display the authorization code to the user instead of redirecting to a web page.
-     *  Must match one of the redirect_uris declared during app registration.
+     * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#authorize">Mastodon oauth API methods #authorize</a>
      */
-    @JvmOverloads
-    fun getOAuthUrl(clientId: String, scope: Scope, redirectUri: String = "urn:ietf:wg:oauth:2.0:oob"): String {
+    fun getOAuthUrl(clientId: String, scope: Scope, redirectUri: String): String {
         val endpoint = "oauth/authorize"
         val params = Parameters()
             .append("client_id", clientId)
@@ -39,17 +36,14 @@ class OAuthMethods(private val client: MastodonClient) {
      * Obtain a user access token using OAuth 2 authorization code grant type. To be used during API calls that are not public.
      * @param clientId The client ID, obtained during app registration.
      * @param clientSecret The client secret, obtained during app registration.
-     * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
-     *  which will display the authorization code to the user instead of redirecting to a web page.
-     *  Must match one of the redirect_uris declared during app registration.
+     * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @param code A user authorization code, obtained via the URL received from getOAuthUrl()
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
-    @JvmOverloads
     fun getUserAccessTokenWithAuthorizationCodeGrant(
         clientId: String,
         clientSecret: String,
-        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUri: String,
         code: String
     ): MastodonRequest<Token> {
         return client.getMastodonRequest(
@@ -69,9 +63,7 @@ class OAuthMethods(private val client: MastodonClient) {
      * Obtain an access token using OAuth 2 client credentials grant type. To be used during API calls that are not public.
      * @param clientId The client ID, obtained during app registration.
      * @param clientSecret The client secret, obtained during app registration.
-     * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
-     *  which will display the authorization code to the user instead of redirecting to a web page.
-     *  Must match one of the redirect_uris declared during app registration.
+     * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @param scope Requested OAuth scopes. Must be a subset of scopes declared during app registration.
      *  If not provided, defaults to read.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
@@ -81,7 +73,7 @@ class OAuthMethods(private val client: MastodonClient) {
     fun getAccessTokenWithClientCredentialsGrant(
         clientId: String,
         clientSecret: String,
-        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUri: String,
         scope: Scope? = null
     ): MastodonRequest<Token> {
         return client.getMastodonRequest(
@@ -105,8 +97,7 @@ class OAuthMethods(private val client: MastodonClient) {
      * @param clientId The client ID, obtained during app registration.
      * @param clientSecret The client secret, obtained during app registration.
      * @param scope Requested OAuth scopes
-     * @param redirectUri Set a URI to redirect the user to. Defaults to "urn:ietf:wg:oauth:2.0:oob",
-     *  which will display the authorization code to the user instead of redirecting to a web page.
+     * @param redirectUri Set a URI to redirect the user to.
      * @param username The Mastodon account username.
      * @param password The Mastodon account password.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
@@ -116,7 +107,7 @@ class OAuthMethods(private val client: MastodonClient) {
         clientId: String,
         clientSecret: String,
         scope: Scope = Scope(Scope.Name.READ),
-        redirectUri: String = "urn:ietf:wg:oauth:2.0:oob",
+        redirectUri: String,
         username: String,
         password: String
     ): MastodonRequest<Token> {

--- a/bigbone/src/test/kotlin/social/bigbone/TestConstants.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/TestConstants.kt
@@ -1,0 +1,5 @@
+package social.bigbone
+
+object TestConstants {
+    const val REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+}

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.MastodonClient
+import social.bigbone.TestConstants
 import social.bigbone.api.Scope
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
@@ -17,7 +18,9 @@ class AppMethodsTest {
 
         val appMethods = AppMethods(client)
         val application = appMethods.createApp(
-            clientName = "bigbone-sample-app", scope = Scope(Scope.Name.ALL)
+            clientName = "bigbone-sample-app",
+            redirectUris = TestConstants.REDIRECT_URI,
+            scope = Scope(Scope.Name.ALL)
         ).execute()
 
         application.clientId shouldBeEqualTo "client id"
@@ -30,7 +33,9 @@ class AppMethodsTest {
             val client = MockClient.ioException()
             val appMethods = AppMethods(client)
             appMethods.createApp(
-                clientName = "bigbone-sample-app", scope = Scope(Scope.Name.ALL)
+                clientName = "bigbone-sample-app",
+                redirectUris = TestConstants.REDIRECT_URI,
+                scope = Scope(Scope.Name.ALL)
             ).execute()
         }
     }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
@@ -6,6 +6,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.MastodonClient
+import social.bigbone.TestConstants
 import social.bigbone.api.Scope
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
@@ -20,7 +21,11 @@ class OAuthMethodsTest {
         every { client.getScheme() } returns "https"
         every { client.getPort() } returns 443
 
-        val url = OAuthMethods(client).getOAuthUrl("client_id", Scope(Scope.Name.ALL))
+        val url = OAuthMethods(client).getOAuthUrl(
+            clientId = "client_id",
+            scope = Scope(Scope.Name.ALL),
+            redirectUri = TestConstants.REDIRECT_URI
+        )
         url shouldBeEqualTo "https://mastodon.cloud/oauth/authorize?client_id=client_id" +
             "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write+follow"
     }
@@ -30,7 +35,12 @@ class OAuthMethodsTest {
         val client: MastodonClient = MockClient.mock("access_token.json")
         every { client.getInstanceName() } returns "mastodon.cloud"
         val oauth = OAuthMethods(client)
-        val accessToken = oauth.getUserAccessTokenWithAuthorizationCodeGrant("test", "test", code = "test").execute()
+        val accessToken = oauth.getUserAccessTokenWithAuthorizationCodeGrant(
+            clientId = "test",
+            clientSecret = "test",
+            redirectUri = TestConstants.REDIRECT_URI,
+            code = "test"
+        ).execute()
         accessToken.accessToken shouldBeEqualTo "test"
         accessToken.scope shouldBeEqualTo "read write follow"
         accessToken.tokenType shouldBeEqualTo "bearer"
@@ -43,7 +53,12 @@ class OAuthMethodsTest {
             val client: MastodonClient = MockClient.ioException()
             every { client.getInstanceName() } returns "mastodon.cloud"
             val oauth = OAuthMethods(client)
-            oauth.getUserAccessTokenWithAuthorizationCodeGrant("test", "test", code = "test").execute()
+            oauth.getUserAccessTokenWithAuthorizationCodeGrant(
+                clientId = "test",
+                clientSecret = "test",
+                redirectUri = TestConstants.REDIRECT_URI,
+                code = "test"
+            ).execute()
         }
     }
 
@@ -52,7 +67,11 @@ class OAuthMethodsTest {
         val client: MastodonClient = MockClient.mock("access_token.json")
         every { client.getInstanceName() } returns "mastodon.cloud"
         val oauth = OAuthMethods(client)
-        val accessToken = oauth.getAccessTokenWithClientCredentialsGrant("test", "test").execute()
+        val accessToken = oauth.getAccessTokenWithClientCredentialsGrant(
+            clientId = "test",
+            clientSecret = "test",
+            redirectUri = TestConstants.REDIRECT_URI
+        ).execute()
         accessToken.accessToken shouldBeEqualTo "test"
         accessToken.scope shouldBeEqualTo "read write follow"
         accessToken.tokenType shouldBeEqualTo "bearer"
@@ -65,7 +84,11 @@ class OAuthMethodsTest {
             val client: MastodonClient = MockClient.ioException()
             every { client.getInstanceName() } returns "mastodon.cloud"
             val oauth = OAuthMethods(client)
-            oauth.getAccessTokenWithClientCredentialsGrant("test", "test").execute()
+            oauth.getAccessTokenWithClientCredentialsGrant(
+                clientId = "test",
+                clientSecret = "test",
+                redirectUri = TestConstants.REDIRECT_URI
+            ).execute()
         }
     }
 
@@ -78,7 +101,7 @@ class OAuthMethodsTest {
             "test",
             "test",
             Scope(Scope.Name.ALL),
-            "urn:ietf:wg:oauth:2.0:oob",
+            TestConstants.REDIRECT_URI,
             "test",
             "test"
         ).execute()
@@ -94,7 +117,14 @@ class OAuthMethodsTest {
             val client: MastodonClient = MockClient.ioException()
             every { client.getInstanceName() } returns "mastodon.cloud"
             val oauth = OAuthMethods(client)
-            oauth.getUserAccessTokenWithPasswordGrant("test", "test", Scope(Scope.Name.ALL), "urn:ietf:wg:oauth:2.0:oob", "test", "test").execute()
+            oauth.getUserAccessTokenWithPasswordGrant(
+                clientId = "test",
+                clientSecret = "test",
+                scope = Scope(Scope.Name.ALL),
+                redirectUri = TestConstants.REDIRECT_URI,
+                username = "test",
+                password = "test"
+            ).execute()
         }
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
@@ -17,6 +17,7 @@ final class Authenticator {
     private static final String CLIENT_ID = "client_id";
     private static final String CLIENT_SECRET = "client_secret";
     private static final String ACCESS_TOKEN = "access_token";
+    private static final String REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 
     private Authenticator() {}
 
@@ -63,11 +64,11 @@ final class Authenticator {
     private static Token getAccessToken(final String instanceName, final String clientId, final String clientSecret, final String email, final String password) throws BigBoneRequestException {
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
         final OAuthMethods oauthMethods = new OAuthMethods(client);
-        return oauthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, new Scope(), email, password).execute();
+        return oauthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, new Scope(), REDIRECT_URI, email, password).execute();
     }
 
     private static Application application(final String instanceName) throws BigBoneRequestException {
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
-        return client.apps().createApp("bigbone-sample-app", "urn:ietf:wg:oauth:2.0:oob", new Scope(), null).execute();
+        return client.apps().createApp("bigbone-sample-app", REDIRECT_URI, new Scope(), null).execute();
     }
 }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
@@ -12,6 +12,7 @@ object Authenticator {
     private const val CLIENT_ID = "client_id"
     private const val CLIENT_SECRET = "client_secret"
     private const val ACCESS_TOKEN = "access_token"
+    private const val REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 
     fun appRegistrationIfNeeded(instanceName: String, credentialFilePath: String, useStreaming: Boolean = false): MastodonClient {
         val file = File(credentialFilePath)
@@ -71,13 +72,14 @@ object Authenticator {
     ): Token {
         val client = MastodonClient.Builder(instanceName).build()
         val oAuthMethods = OAuthMethods(client)
-        return oAuthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, Scope(), "urn:ietf:wg:oauth:2.0:oob", email, password).execute()
+        return oAuthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, Scope(), REDIRECT_URI, email, password).execute()
     }
 
     private fun appRegistration(instanceName: String): Application {
         val client = MastodonClient.Builder(instanceName).build()
         return client.apps.createApp(
-            "bigbone-sample-app",
+            clientName = "bigbone-sample-app",
+            redirectUris = REDIRECT_URI,
             scope = Scope()
         ).execute()
     }


### PR DESCRIPTION
Default value was the out-of-band URI "urn:ietf:wg:oauth:2.0:oob", which is not useful in most production contexts. Keeping it as a default might lead to hard-to-debug situations where an actually sensible parameter is omitted and authentication fails as a result of this. The out-of-band URI can still be used, but needs to be specified.

Closes #155.