### PR TITLE
potential fix for OkHttp connection leakage while streaming

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/Shutdownable.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Shutdownable.kt
@@ -1,5 +1,6 @@
 package social.bigbone.api
 
+import okhttp3.Response
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -7,15 +8,16 @@ import kotlin.concurrent.withLock
  * Shutdownable is used by streaming endpoints, such as [social.bigbone.api.method.StreamingMethods.federatedPublic]. It
  * gives the caller a way of closing the stream, by calling the [shutdown] method.
  */
-class Shutdownable(private val dispatcher: Dispatcher) {
+class Shutdownable(private val dispatcher: Dispatcher, private val response: Response) {
     private val lock = ReentrantLock()
 
     /**
-     * Close the current stream.
+     * Close the current stream as well as the response body the stream is based on.
      */
     fun shutdown() {
         lock.withLock {
             dispatcher.shutdown()
         }
+        response.close()
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/StreamingMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/StreamingMethods.kt
@@ -51,9 +51,11 @@ class StreamingMethods(private val client: MastodonClient) {
                     }
                 }
                 reader.close()
+                response.close()
             }
-            return Shutdownable(dispatcher)
+            return Shutdownable(dispatcher, response)
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }
@@ -95,9 +97,11 @@ class StreamingMethods(private val client: MastodonClient) {
                     }
                 }
                 reader.close()
+                response.close()
             }
-            return Shutdownable(dispatcher)
+            return Shutdownable(dispatcher, response)
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }
@@ -142,9 +146,11 @@ class StreamingMethods(private val client: MastodonClient) {
                     }
                 }
                 reader.close()
+                response.close()
             }
-            return Shutdownable(dispatcher)
+            return Shutdownable(dispatcher, response)
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }
@@ -189,9 +195,11 @@ class StreamingMethods(private val client: MastodonClient) {
                     }
                 }
                 reader.close()
+                response.close()
             }
-            return Shutdownable(dispatcher)
+            return Shutdownable(dispatcher, response)
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }
@@ -250,9 +258,11 @@ class StreamingMethods(private val client: MastodonClient) {
                     }
                 }
                 reader.close()
+                response.close()
             }
-            return Shutdownable(dispatcher)
+            return Shutdownable(dispatcher, response)
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }
@@ -314,9 +324,11 @@ class StreamingMethods(private val client: MastodonClient) {
                     }
                 }
                 reader.close()
+                response.close()
             }
-            return Shutdownable(dispatcher)
+            return Shutdownable(dispatcher, response)
         } else {
+            response.close()
             throw BigBoneRequestException(response)
         }
     }


### PR DESCRIPTION
As a potential fix for OkHttp connection leakage while using the Streaming API, this closes response body if:
- response is not successful
- response is successful, but a `java.io.InterruptedIOException` is encountered
- user initiates shutdown of stream via `Shutdownable.shutdown()`

Work towards #123. A full refactoring of the Streaming API still needs to happen and is scheduled for 2.1.0, so this PR does not include anything beyond the most basic band-aid.