### PR TITLE
potential fix for OkHttp connection leakage while building client

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -10,7 +10,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import social.bigbone.api.Pageable
-import social.bigbone.api.entity.InstanceVersion
+import social.bigbone.api.entity.data.InstanceVersion
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.api.method.AccountMethods
 import social.bigbone.api.method.AppMethods
@@ -516,16 +516,34 @@ private constructor(
             this.debug = true
         }
 
+        /**
+         * Get the version string for this Mastodon instance.
+         * @return a string corresponding to the version of this Mastodon instance
+         * @throws BigBoneRequestException if instance version can not be retrieved using any API version
+         */
         private fun getInstanceVersion(): String {
-            try {
-                return listOf(v2InstanceRequest(), v1InstanceRequest()).stream()
-                    .filter { response -> response.isSuccessful }
-                    .map { response -> gson.fromJson(response.body?.string(), InstanceVersion::class.java) }
-                    .map { json -> json.version }
-                    .findFirst()
-                    .get()
+            val instanceVersion = getInstanceVersion(2) ?: getInstanceVersion(1)
+            return instanceVersion ?: throw BigBoneRequestException("Unable to fetch instance version")
+        }
+
+        /**
+         * Get the version string for this Mastodon instance, using a specific API version.
+         * @param apiVersion the version of API call to use in this request
+         * @return a string corresponding to the version of this Mastodon instance, or null if no version string can be
+         *  retrieved using the specified API version.
+         */
+        private fun getInstanceVersion(apiVersion: Int): String? {
+            return try {
+                val response = versionedInstanceRequest(apiVersion)
+                if (response.isSuccessful) {
+                    val instanceVersion = gson.fromJson(response.body?.string(), InstanceVersion::class.java)
+                    instanceVersion.version
+                } else {
+                    response.close()
+                    null
+                }
             } catch (e: Exception) {
-                throw BigBoneRequestException("Unable to fetch instance version", e)
+                null
             }
         }
 
@@ -538,24 +556,13 @@ private constructor(
         }
 
         /**
-         * Returns the server response for an instance request of version 2.
-         * @return server response for this request; if the response is not successful, its body will be closed
-         */
-        internal fun v2InstanceRequest(): Response = versionedInstanceRequest(2)
-
-        /**
-         * Returns the server response for an instance request of version 1.
-         * @return server response for this request; if the response is not successful, its body will be closed
-         */
-        internal fun v1InstanceRequest(): Response = versionedInstanceRequest(1)
-
-        /**
-         * Returns the server response for an instance request of a specific version.
+         * Returns the server response for an instance request of a specific version. This response needs to be closed
+         * by the caller, either by reading from it via response.body?.string(), or by calling response.close().
          * @param version value corresponding to the version that should be returned; falls
          *  back to returning version 1 for illegal values.
-         * @return server response for this request; if the response is not successful, its body will be closed
+         * @return server response for this request
          */
-        private fun versionedInstanceRequest(version: Int): Response {
+        internal fun versionedInstanceRequest(version: Int): Response {
             val versionString = if (version == 2) {
                 "v2"
             } else {
@@ -566,15 +573,13 @@ private constructor(
                 configureForTrustAll(clientBuilder)
             }
             val client = clientBuilder.build()
-            val response = client.newCall(
+            return client.newCall(
                 Request.Builder().url(
-                    fullUrl(scheme, instanceName, port, "api/$versionString/instance"
+                    fullUrl(
+                        scheme, instanceName, port, "api/$versionString/instance"
                     )
-                ).get().build()).execute()
-            if (!response.isSuccessful) {
-                response.close()
-            }
-            return response
+                ).get().build()
+            ).execute()
         }
 
         fun build(): MastodonClient {

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/data/InstanceVersion.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/data/InstanceVersion.kt
@@ -1,4 +1,4 @@
-package social.bigbone.api.entity
+package social.bigbone.api.entity.data
 
 import com.google.gson.annotations.SerializedName
 

--- a/bigbone/src/test/kotlin/social/bigbone/MastodonClientTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/MastodonClientTest.kt
@@ -309,8 +309,8 @@ class MastodonClientTest {
         val responseV1Mock = mockk<Response>()
 
         val clientBuilder = spyk(MastodonClient.Builder("foo.bar"))
-        every { clientBuilder.v2InstanceRequest() } answers { responseV2Mock }
-        every { clientBuilder.v1InstanceRequest() } answers { responseV1Mock }
+        every { clientBuilder.versionedInstanceRequest(1) } answers { responseV1Mock }
+        every { clientBuilder.versionedInstanceRequest(2) } answers { responseV2Mock }
 
         // when
         val client = clientBuilder.build()
@@ -332,8 +332,8 @@ class MastodonClientTest {
         every { responseV1Mock.body } answers { responseBodyV1Mock }
 
         val clientBuilder = spyk(MastodonClient.Builder("foo.bar"))
-        every { clientBuilder.v2InstanceRequest() } answers { responseV2Mock }
-        every { clientBuilder.v1InstanceRequest() } answers { responseV1Mock }
+        every { clientBuilder.versionedInstanceRequest(1) } answers { responseV1Mock }
+        every { clientBuilder.versionedInstanceRequest(2) } answers { responseV2Mock }
 
         // when
         val client = clientBuilder.build()
@@ -349,8 +349,7 @@ class MastodonClientTest {
         val responseMock = mockk<Response>()
         every { responseMock.body } answers { invalidResponseBody.toResponseBody("application/json".toMediaType()) }
         every { responseMock.isSuccessful } answers { true }
-        every { clientBuilder.v2InstanceRequest() } answers { responseMock }
-        every { clientBuilder.v1InstanceRequest() } answers { responseMock }
+        every { clientBuilder.versionedInstanceRequest(any()) } answers { responseMock }
 
         // when / then
         Assertions.assertThrows(BigBoneRequestException::class.java) {


### PR DESCRIPTION
- requests to v1 and v2 endpoints are now performed separately, each one closing its response.body in both success and failure cases.
- moving InstanceVersion to new data package for data classes that are not public Mastodon entities.

Work towards #123