### PR TITLE
Reconfigure checkstyle spacing rules

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -30,13 +30,8 @@
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
-        <module name="WhitespaceAfter">
-            <property name="tokens" value="COMMA, SEMI"/>
-        </module>
-        <!--<module name="WhitespaceAround">-->
-        <!-- everything except { and } -->
-        <!--<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>-->
-        <!--</module>-->
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
 
         <!-- Coding -->
         <module name="CovariantEquals"/>

--- a/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
@@ -19,7 +19,7 @@ final class Authenticator {
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 
-    private Authenticator() {}
+    private Authenticator() { }
 
     static MastodonClient appRegistrationIfNeeded(final String instanceName, final String credentialFilePath, final boolean useStreaming) throws IOException, BigBoneRequestException {
         final File file = new File(credentialFilePath);


### PR DESCRIPTION
This reconfigures the checkstyle whitespace rules. In this particular case, the rule change enforces whitespaces around things such as operators, brackets, etc. Doing so, we are more in line with Java code formatting best practices.