### PR TITLE
sample to showcase potential filtering in home timeline

### DIFF
--- a/sample-java/src/main/java/social/bigbone/sample/GetHomeTimelineWithFiltering.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetHomeTimelineWithFiltering.java
@@ -1,0 +1,68 @@
+package social.bigbone.sample;
+
+import social.bigbone.MastodonClient;
+import social.bigbone.api.Pageable;
+import social.bigbone.api.entity.Filter;
+import social.bigbone.api.entity.Status;
+import social.bigbone.api.exception.BigBoneRequestException;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class GetHomeTimelineWithFiltering {
+
+    public static void main(final String[] args) throws BigBoneRequestException {
+        final String instance = args[0];
+        final String accessToken = args[1];
+
+        // Instantiate client
+        final MastodonClient client = new MastodonClient.Builder(instance)
+                .accessToken(accessToken)
+                .build();
+
+        // Get statuses from home timeline, then handle each one
+        final Pageable<Status> statuses = client.timelines().getHomeTimeline().execute();
+        statuses.getPart().forEach(status -> {
+
+            // determine if we need to hide the status or just warn about it
+            AtomicBoolean shouldWarn = new AtomicBoolean(false);
+            AtomicBoolean shouldHide = new AtomicBoolean(false);
+            if (status.getFiltered() != null) {
+                status.getFiltered().forEach(filterResult -> {
+                    Filter filter = filterResult.getFilter();
+
+                    // only use a filter if it applies to our current context (in this case, the home timeline)
+                    if (filter.getContext().contains(Filter.Context.Home.getValue())) {
+
+                        // check the filter action set for this filter
+                        if (filter.getFilterAction().equals(Filter.Action.Warn.getValue())) {
+                            shouldWarn.set(true);
+                        }
+                        if (filter.getFilterAction().equals(Filter.Action.Hide.getValue())) {
+                            shouldHide.set(true);
+                        }
+
+                    }
+                });
+            }
+
+            // display the status as is appropriate
+            if (!shouldHide.get()) {
+                // hidden statuses are skipped completely
+
+                // display warning, or post content if no filters matched
+                String name = "someone";
+                if (status.getAccount() != null) {
+                    name = status.getAccount().getDisplayName();
+                }
+                if (shouldWarn.get()) {
+                    System.out.println("********************************************************************************");
+                    System.out.println("* WARNING * status by " + name + " matches one or more of your filters");
+                    System.out.println("********************************************************************************");
+                } else {
+                    final String content = status.getContent();
+                    System.out.println(name + " posted: " + content);
+                }
+            }
+        });
+    }
+}

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetHomeTimelineWithFiltering.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/GetHomeTimelineWithFiltering.kt
@@ -1,0 +1,55 @@
+package social.bigbone.sample
+
+import social.bigbone.MastodonClient
+import social.bigbone.api.entity.Filter
+
+object GetHomeTimelineWithFiltering {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val instance = args[0]
+        val accessToken = args[1]
+
+        // Instantiate client
+        val client = MastodonClient.Builder(instance)
+            .accessToken(accessToken)
+            .build()
+
+        // Get statuses from home timeline, then handle each one
+        val statuses = client.timelines.getHomeTimeline().execute()
+        statuses.part.forEach { status ->
+
+            // determine if we need to hide the status or just warn about it
+            var shouldWarn = false
+            var shouldHide = false
+            status.filtered?.let { filterResultList ->
+                filterResultList.forEach {
+                    val filter = it.filter
+
+                    // only use a filter if it applies to our current context (in this case, the home timeline)
+                    if (filter.context.contains(Filter.Context.Home.value)) {
+
+                        // check the filter action set for this filter
+                        when (filter.filterAction) {
+                            Filter.Action.Warn.value -> shouldWarn = true
+                            Filter.Action.Hide.value -> shouldHide = true
+                        }
+                    }
+                }
+            }
+
+            // display the status as is appropriate
+            if (!shouldHide) {
+                // hidden statuses are skipped completely
+
+                // display warning, or post content if no filters matched
+                if (shouldWarn) {
+                    println("********************************************************************************")
+                    println("* WARNING * status by ${status.account?.displayName} matches one or more of your filters")
+                    println("********************************************************************************")
+                } else {
+                    println("${status.account?.displayName} posted: ${status.content.take(50)}")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to the already closed #214, here's another sample to showcase filter usage, this time when actually presenting statuses that might be affected by a filter the user previously created.