### PR TITLE
fix some endpoint paths, avoiding empty path segments

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/FilterMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/FilterMethods.kt
@@ -180,7 +180,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun addKeyword(filterId: String, filterKeyword: FilterKeyword): MastodonRequest<FilterKeyword> {
         return client.getMastodonRequest(
-            endpoint = "/api/v2/filters/$filterId/keywords",
+            endpoint = "api/v2/filters/$filterId/keywords",
             method = MastodonClient.Method.POST,
             Parameters().apply {
                 append("keyword", filterKeyword.keyword)
@@ -197,7 +197,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun viewKeyword(keywordId: String): MastodonRequest<FilterKeyword> {
         return client.getMastodonRequest(
-            endpoint = "/api/v2/filters/keywords/$keywordId",
+            endpoint = "api/v2/filters/keywords/$keywordId",
             method = MastodonClient.Method.GET
         )
     }
@@ -210,7 +210,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun updateKeyword(filterKeyword: FilterKeyword): MastodonRequest<FilterKeyword> {
         return client.getMastodonRequest(
-            endpoint = "/api/v2/filters/keywords/${filterKeyword.id}",
+            endpoint = "api/v2/filters/keywords/${filterKeyword.id}",
             method = MastodonClient.Method.PUT,
             Parameters().apply {
                 append("keyword", filterKeyword.keyword)
@@ -227,7 +227,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun deleteKeyword(keywordId: String) {
         client.performAction(
-            endpoint = "/api/v2/filters/keywords/$keywordId",
+            endpoint = "api/v2/filters/keywords/$keywordId",
             method = MastodonClient.Method.DELETE
         )
     }
@@ -240,7 +240,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun listStatusFilters(filterId: String): MastodonRequest<List<FilterStatus>> {
         return client.getMastodonRequestForList(
-            endpoint = "/api/v2/filters/$filterId/statuses",
+            endpoint = "api/v2/filters/$filterId/statuses",
             method = MastodonClient.Method.GET
         )
     }
@@ -252,7 +252,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun addStatusToFilter(filterId: String, statusId: String): MastodonRequest<FilterStatus> {
         return client.getMastodonRequest(
-            endpoint = "/api/v2/filters/$filterId/statuses",
+            endpoint = "api/v2/filters/$filterId/statuses",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("status_id", statusId)
@@ -268,7 +268,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun viewStatusFilter(filterStatusId: String): MastodonRequest<FilterStatus> {
         return client.getMastodonRequest(
-            endpoint = "/api/v2/filters/statuses/$filterStatusId",
+            endpoint = "api/v2/filters/statuses/$filterStatusId",
             method = MastodonClient.Method.GET
         )
     }
@@ -281,7 +281,7 @@ class FilterMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun removeStatusFromFilter(filterStatusId: String): MastodonRequest<FilterStatus> {
         return client.getMastodonRequest(
-            endpoint = "/api/v2/filters/statuses/$filterStatusId",
+            endpoint = "api/v2/filters/statuses/$filterStatusId",
             method = MastodonClient.Method.DELETE
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/PollMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/PollMethods.kt
@@ -21,7 +21,7 @@ class PollMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun viewPoll(pollId: String): MastodonRequest<Poll> {
         return client.getMastodonRequest(
-            endpoint = "/api/v1/polls/$pollId",
+            endpoint = "api/v1/polls/$pollId",
             method = MastodonClient.Method.GET
         )
     }
@@ -36,7 +36,7 @@ class PollMethods(private val client: MastodonClient) {
     @Throws(BigBoneRequestException::class)
     fun voteOnPoll(pollId: String, choices: List<Int>): MastodonRequest<Poll> {
         return client.getMastodonRequest(
-            endpoint = "/api/v1/polls/$pollId/votes",
+            endpoint = "api/v1/polls/$pollId/votes",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 appendInts("choices", choices)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/TagMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/TagMethods.kt
@@ -17,7 +17,7 @@ class TagMethods(private val client: MastodonClient) {
      */
     fun getTag(tagId: String): MastodonRequest<Tag> {
         return client.getMastodonRequest(
-            endpoint = "/api/v1/tags/$tagId",
+            endpoint = "api/v1/tags/$tagId",
             method = MastodonClient.Method.GET
         )
     }
@@ -29,7 +29,7 @@ class TagMethods(private val client: MastodonClient) {
      */
     fun followTag(tagId: String): MastodonRequest<Tag> {
         return client.getMastodonRequest(
-            endpoint = "/api/v1/tags/$tagId/follow",
+            endpoint = "api/v1/tags/$tagId/follow",
             method = MastodonClient.Method.POST
         )
     }
@@ -41,7 +41,7 @@ class TagMethods(private val client: MastodonClient) {
      */
     fun unfollowTag(tagId: String): MastodonRequest<Tag> {
         return client.getMastodonRequest(
-            endpoint = "/api/v1/tags/$tagId/unfollow",
+            endpoint = "api/v1/tags/$tagId/unfollow",
             method = MastodonClient.Method.POST
         )
     }


### PR DESCRIPTION
Some method endpoints were defined with a leading `/` that would have led to empty path segments `...//...` in the resulting URL.