### PR TITLE
add Idempotency-Key header to post status requests

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/Parameters.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/Parameters.kt
@@ -2,6 +2,7 @@ package social.bigbone
 
 import java.net.URLEncoder
 import java.util.ArrayList
+import java.util.UUID
 
 /**
  * Parameters holds a list of String key/value pairs that can be used as query part of a URL, or in the body of a request.
@@ -80,4 +81,18 @@ class Parameters {
         parameterList.joinToString(separator = "&") {
             "${it.first}=${URLEncoder.encode(it.second, "utf-8")}"
         }
+
+    /**
+     * Generates a UUID string for this parameter list. UUIDs returned for different Parameters instances should be
+     *  the same if they contain the same list of key/value pairs, even if pairs were appended in different order,
+     *  and should be different as soon as at least one parameter key or value differs.
+     * @return Type 3 UUID as a String.
+     */
+    fun uuid(): String {
+        val parameterString = parameterList
+            .sortedWith(compareBy { it.first })
+            .joinToString { "${it.first}${it.second}" }
+        val uuid = UUID.nameUUIDFromBytes(parameterString.toByteArray())
+        return uuid.toString()
+    }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/StatusMethods.kt
@@ -131,7 +131,8 @@ class StatusMethods(private val client: MastodonClient) {
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
                 language?.let { append("language", it) }
-            }
+            },
+            addIdempotencyKey = true
         )
     }
 
@@ -171,7 +172,8 @@ class StatusMethods(private val client: MastodonClient) {
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
                 language?.let { append("language", it) }
-            }
+            },
+            addIdempotencyKey = true
         )
     }
 
@@ -212,7 +214,8 @@ class StatusMethods(private val client: MastodonClient) {
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
                 language?.let { append("language", it) }
-            }
+            },
+            addIdempotencyKey = true
         )
     }
 
@@ -255,7 +258,8 @@ class StatusMethods(private val client: MastodonClient) {
                 append("sensitive", sensitive)
                 spoilerText?.let { append("spoiler_text", it) }
                 language?.let { append("language", it) }
-            }
+            },
+            addIdempotencyKey = true
         )
     }
 

--- a/bigbone/src/test/kotlin/social/bigbone/ParametersTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/ParametersTest.kt
@@ -1,6 +1,7 @@
 package social.bigbone
 
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.jupiter.api.Test
 
 class ParametersTest {
@@ -31,5 +32,42 @@ class ParametersTest {
         Parameters()
             .append("media_ids", listOf(1, 3, 4))
             .toQuery() shouldBeEqualTo "media_ids[]=1&media_ids[]=3&media_ids[]=4"
+    }
+
+    @Test
+    fun sameUuidWithDifferentParameterOrder() {
+        val params1 = Parameters()
+            .append("One", "1")
+            .append("Two", "2")
+            .append("Three", "3")
+
+        val params2 = Parameters()
+            .append("Three", "3")
+            .append("Two", "2")
+            .append("One", "1")
+
+        params1.uuid() shouldBeEqualTo params2.uuid()
+    }
+
+    @Test
+    fun differentUuidWithDifferentKey() {
+        val params1 = Parameters()
+            .append("Key", "foo")
+
+        val params2 = Parameters()
+            .append("OtherKey", "foo")
+
+        params1.uuid() shouldNotBeEqualTo params2.uuid()
+    }
+
+    @Test
+    fun differentUuidWithDifferentValue() {
+        val params1 = Parameters()
+            .append("Key", "foo")
+
+        val params2 = Parameters()
+            .append("Key", "bar")
+
+        params1.uuid() shouldNotBeEqualTo params2.uuid()
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
@@ -46,6 +46,7 @@ object MockClient {
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
+        every { clientMock.post(ofType<String>(), any(), any()) } returns response
         every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.put(ofType<String>(), any()) } returns response
         every { clientMock.getSerializer() } returns Gson()
@@ -69,6 +70,7 @@ object MockClient {
         every { clientMock.get(ofType<String>(), any()) } returns response
         every { clientMock.patch(ofType<String>(), any()) } returns response
         every { clientMock.post(ofType<String>(), any()) } returns response
+        every { clientMock.post(ofType<String>(), any(), any()) } returns response
         every { clientMock.postRequestBody(ofType<String>(), any()) } returns response
         every { clientMock.put(ofType<String>(), any()) } returns response
         every { clientMock.performAction(ofType<String>(), any()) } throws BigBoneRequestException("mock")


### PR DESCRIPTION
Under the assumption that the idempotency key string used to identify repeat requests does not need to be manually set by library users themselves, this generates key string as a type 3 UUID from the alphabetically sorted parameter list of a request, ensuring that the key string will be identical if and only if the parameter list is the same.

If that assumption is correct, closes #118.