### PR TITLE
Return instance version from server info if available

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -614,11 +614,12 @@ private constructor(
          */
         private fun getInstanceVersion(): String {
             try {
-                NodeInfoClient
+                val serverInfoVersion = NodeInfoClient
                     .retrieveServerInfo(instanceName)
                     ?.software
                     ?.takeIf { it.name == "mastodon" }
                     ?.version
+                if (serverInfoVersion != null) return serverInfoVersion
             } catch (_: BigBoneRequestException) {
             }
 


### PR DESCRIPTION
# Description

#270 accidentally added a change where the instance version was no longer returned even if we got one from the `NodeInfoClient`, so we always fell back to getting the instance info through the Mastodon API.

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Dependency update / replacement

# How Has This Been Tested?

`gradle check`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
