### PR TITLE
Add custom_emojis API methods

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxCustomEmojisMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxCustomEmojisMethods.kt
@@ -1,0 +1,25 @@
+package social.bigbone.rx
+
+import io.reactivex.rxjava3.core.Single
+import social.bigbone.MastodonClient
+import social.bigbone.api.entity.CustomEmoji
+import social.bigbone.api.method.CustomEmojisMethods
+
+/**
+ * Reactive implementation of [CustomEmojisMethods].
+ * Allows access to API methods with endpoints having an "api/vX/custom_emojis" prefix.
+ * Each site can define and upload its own custom emoji to be attached to profiles or statuses.
+ * @see <a href="https://docs.joinmastodon.org/methods/custom_emojis/">Mastodon custom_emojis API methods</a>
+ */
+class RxCustomEmojisMethods(client: MastodonClient) {
+
+    private val customEmojisMethods = CustomEmojisMethods(client)
+
+    /**
+     * Returns custom emojis that are available on the server.
+     * * @see <a href="https://docs.joinmastodon.org/methods/custom_emojis/#get">Mastodon API documentation: methods/custom_emojis/#get</a>
+     */
+    fun getAllCustomEmoji(): Single<List<CustomEmoji>> = Single.fromCallable {
+        customEmojisMethods.getAllCustomEmoji().execute()
+    }
+}

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -16,6 +16,7 @@ import social.bigbone.api.method.AppMethods
 import social.bigbone.api.method.BlockMethods
 import social.bigbone.api.method.BookmarkMethods
 import social.bigbone.api.method.ConversationMethods
+import social.bigbone.api.method.CustomEmojisMethods
 import social.bigbone.api.method.DirectoryMethods
 import social.bigbone.api.method.DomainBlocksMethods
 import social.bigbone.api.method.EndorsementMethods
@@ -96,6 +97,13 @@ private constructor(
     @Suppress("unused") // public API
     @get:JvmName("conversations")
     val conversations: ConversationMethods by lazy { ConversationMethods(this) }
+
+    /**
+     * Access API methods under "api/vX/custom_emojis" endpoint.
+     */
+    @Suppress("unused") // public API
+    @get:JvmName("customEmojis")
+    val customEmojis: CustomEmojisMethods by lazy { CustomEmojisMethods(this) }
 
     /**
      * Access API methods under "api/vX/directory" endpoint.

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/CustomEmojisMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/CustomEmojisMethods.kt
@@ -1,0 +1,26 @@
+package social.bigbone.api.method
+
+import social.bigbone.MastodonClient
+import social.bigbone.MastodonRequest
+import social.bigbone.api.entity.CustomEmoji
+
+/**
+ * Allows access to API methods with endpoints having an "api/vX/custom_emojis" prefix.
+ * Each site can define and upload its own custom emoji to be attached to profiles or statuses.
+ * @see <a href="https://docs.joinmastodon.org/methods/custom_emojis/">Mastodon custom_emojis API methods</a>
+ */
+class CustomEmojisMethods(private val client: MastodonClient) {
+
+    private val customEmojisEndpoint = "api/v1/custom_emojis"
+
+    /**
+     * Returns custom emojis that are available on the server.
+     * * @see <a href="https://docs.joinmastodon.org/methods/custom_emojis/#get">Mastodon API documentation: methods/custom_emojis/#get</a>
+     */
+    fun getAllCustomEmoji(): MastodonRequest<List<CustomEmoji>> {
+        return client.getMastodonRequestForList(
+            endpoint = customEmojisEndpoint,
+            method = MastodonClient.Method.GET
+        )
+    }
+}

--- a/bigbone/src/test/assets/custom_emojis_success.json
+++ b/bigbone/src/test/assets/custom_emojis_success.json
@@ -1,0 +1,33 @@
+[
+  {
+    "shortcode": "aaaa",
+    "url": "https://files.mastodon.social/custom_emojis/images/000/007/118/original/aaaa.png",
+    "static_url": "https://files.mastodon.social/custom_emojis/images/000/007/118/static/aaaa.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "AAAAAA",
+    "url": "https://files.mastodon.social/custom_emojis/images/000/071/387/original/AAAAAA.png",
+    "static_url": "https://files.mastodon.social/custom_emojis/images/000/071/387/static/AAAAAA.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "blobaww",
+    "url": "https://files.mastodon.social/custom_emojis/images/000/011/739/original/blobaww.png",
+    "static_url": "https://files.mastodon.social/custom_emojis/images/000/011/739/static/blobaww.png",
+    "visible_in_picker": true,
+    "category": "Blobs"
+  },
+  {
+    "shortcode": "yikes",
+    "url": "https://files.mastodon.social/custom_emojis/images/000/031/275/original/yikes.png",
+    "static_url": "https://files.mastodon.social/custom_emojis/images/000/031/275/static/yikes.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "ziltoid",
+    "url": "https://files.mastodon.social/custom_emojis/images/000/017/094/original/05252745eb087806.png",
+    "static_url": "https://files.mastodon.social/custom_emojis/images/000/017/094/static/05252745eb087806.png",
+    "visible_in_picker": true
+  }
+]

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/CustomEmojisMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/CustomEmojisMethodsTest.kt
@@ -1,0 +1,49 @@
+package social.bigbone.api.method
+
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import social.bigbone.api.entity.CustomEmoji
+import social.bigbone.api.exception.BigBoneRequestException
+import social.bigbone.testtool.MockClient
+
+class CustomEmojisMethodsTest {
+
+    @Test
+    fun `Given a client returning success, when getting all custom emoji, then expect values of response`() {
+        val client = MockClient.mock(jsonName = "custom_emojis_success.json")
+
+        val customEmojisMethods = CustomEmojisMethods(client)
+
+        with(customEmojisMethods.getAllCustomEmoji().execute()) {
+            shouldHaveSize(5)
+
+            all(CustomEmoji::visibleInPicker).shouldBeTrue()
+
+            get(0).shortcode shouldBeEqualTo "aaaa"
+            get(1).shortcode shouldBeEqualTo "AAAAAA"
+            get(2).shortcode shouldBeEqualTo "blobaww"
+            get(3).shortcode shouldBeEqualTo "yikes"
+            get(4).shortcode shouldBeEqualTo "ziltoid"
+        }
+
+        verify {
+            client.get(
+                path = "api/v1/custom_emojis",
+                query = null
+            )
+        }
+    }
+
+    @Test
+    fun `Given a client failing with an IO exception, when getting all custom emoji, then expect BigBoneRequestException`() {
+        Assertions.assertThrows(BigBoneRequestException::class.java) {
+            val client = MockClient.ioException()
+            val customEmojisMethods = CustomEmojisMethods(client)
+            customEmojisMethods.getAllCustomEmoji().execute()
+        }
+    }
+}


### PR DESCRIPTION
# Description

Implements the [`custom_emojis` API](https://docs.joinmastodon.org/methods/custom_emojis/).

Currently, there’s only one method available to get all custom emoji that are available on the server.

The method is pretty straightforward without any parameters, so nothing fancy here.

Closes #298 

# Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update
  - [API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage) needs an update

# How Has This Been Tested?

`gradle check`

# Mandatory Checklist

- [x] My change follows the projects coding style
- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Optional Things To Check

- [X] In case you worked on new features: Did you also do the Rx part? 
- [X] In case you added new *Methods classes: Did you also add it to `MastodonClient`? 
- [X] In case you worked on endpoints: Please mention in the PR that [API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage) page needs to be updated (if needed)
