### PR TITLE
Proof of concept: MastodonMinServerVersion annotation

### DIFF
--- a/bigbone/build.gradle
+++ b/bigbone/build.gradle
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     api libs.okhttp
 
+    implementation libs.kotlin.reflect
     implementation libs.kotlinx.serialization.json
 
     testImplementation libs.junit.jupiter

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonMinServerVersion.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonMinServerVersion.kt
@@ -1,6 +1,10 @@
 package social.bigbone
 
+import social.bigbone.api.exception.BigBoneVersionException
 import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.math.max
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.findAnnotation
 
 /**
  * Specifies the first version of a Mastodon server where a declaration has appeared.
@@ -13,3 +17,65 @@ import kotlin.annotation.AnnotationTarget.FUNCTION
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 internal annotation class MastodonMinServerVersion(val version: String)
+
+/**
+ * Tries to get the version defined in the [MastodonMinServerVersion] of this [KFunction], if any.
+ *
+ * @return [String] version of the [MastodonMinServerVersion] if this function is annotated, `null` otherwise
+ */
+internal fun <T> KFunction<T>.minMastodonVersion(): String? = findAnnotation<MastodonMinServerVersion>()?.version
+
+/**
+ * Helper function to ensure that the annotated [MastodonMinServerVersion] of this [KFunction] is lower than that of the
+ * instance the [client] is connected to.
+ */
+@Throws(BigBoneVersionException::class)
+fun <T> KFunction<T>.requireMinVersion(client: MastodonClient) {
+    val minMastodonVersion = minMastodonVersion() ?: return
+    val instanceVersion = client.getInstanceVersion() ?: return
+    if (SemanticVersion(instanceVersion) >= SemanticVersion(minMastodonVersion)) return
+
+    throw BigBoneVersionException(
+        methodName = name,
+        minVersion = minMastodonVersion,
+        actualVersion = instanceVersion
+    )
+}
+
+/**
+ * Wrapper to allow comparison of version [String]s that follow semantic versioning.
+ * @see <a href="https://semver.org">SemVer.org</a>
+ */
+private class SemanticVersion(val version: String) {
+
+    init {
+        require(version.matches(versionRegex)) { "String $version doesn't appear to contain a semantic version" }
+    }
+
+    operator fun compareTo(other: SemanticVersion): Int {
+        val thisParts = parts()
+        val otherParts = other.parts()
+        for (i in 0 until max(thisParts.size, otherParts.size)) {
+            val thisPart = if (i < thisParts.size) thisParts[i].toInt() else 0
+            val thatPart = if (i < otherParts.size) otherParts[i].toInt() else 0
+            if (thisPart < thatPart) return -1
+            if (thisPart > thatPart) return 1
+        }
+        return 0
+    }
+
+    private fun parts() = version.split(".")
+
+    companion object {
+        /**
+         * Suggested regular expression to parse all valid SemVer strings.
+         * @see <a href="https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string">SemVer RegEx</a>
+         */
+        private val versionRegex = (
+            """^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)""" +
+                """(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)""" +
+                """(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?""" +
+                """(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?${'$'}"""
+            ).toRegex()
+    }
+}

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonMinServerVersion.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonMinServerVersion.kt
@@ -1,0 +1,15 @@
+package social.bigbone
+
+import kotlin.annotation.AnnotationTarget.FUNCTION
+
+/**
+ * Specifies the first version of a Mastodon server where a declaration has appeared.
+ * In essence, this defines the minimum server version that is required in order to make a call successful.
+ *
+ * @property version the version in the following formats: `<major>.<minor>` or `<major>.<minor>.<patch>`, where major, minor and patch
+ * are non-negative integer numbers without leading zeros.
+ */
+@Target(FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+internal annotation class MastodonMinServerVersion(val version: String)

--- a/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneVersionException.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneVersionException.kt
@@ -1,0 +1,11 @@
+package social.bigbone.api.exception
+
+import social.bigbone.MastodonMinServerVersion
+
+/**
+ * Exception which is thrown if a method annotated with a [MastodonMinServerVersion] requires a higher version of the
+ * Mastodon software to be running on a server than is actually running on it.
+ */
+class BigBoneVersionException(methodName: String, minVersion: String, actualVersion: String) : Exception(
+    "$methodName requires the server to run at least Mastodon $minVersion but it runs $actualVersion"
+)

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/InstanceMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/InstanceMethods.kt
@@ -1,6 +1,7 @@
 package social.bigbone.api.method
 
 import social.bigbone.MastodonClient
+import social.bigbone.MastodonMinServerVersion
 import social.bigbone.MastodonRequest
 import social.bigbone.api.entity.DomainBlock
 import social.bigbone.api.entity.ExtendedDescription
@@ -8,6 +9,8 @@ import social.bigbone.api.entity.Instance
 import social.bigbone.api.entity.InstanceActivity
 import social.bigbone.api.entity.InstanceV1
 import social.bigbone.api.entity.Rule
+import social.bigbone.api.exception.BigBoneVersionException
+import social.bigbone.requireMinVersion
 
 /**
  * Allows access to API methods with endpoints having an "api/vX/instance" prefix.
@@ -21,9 +24,14 @@ class InstanceMethods(private val client: MastodonClient) {
 
     /**
      * Obtain general information about the server.
+     * @throws BigBoneVersionException if the Mastodon server version doesn't match the [MastodonMinServerVersion] for this method
      * @see <a href="https://docs.joinmastodon.org/methods/instance/#v2">Mastodon API documentation: methods/instance/#v2</a>
      */
+    @MastodonMinServerVersion("4.0.0")
+    @Throws(BigBoneVersionException::class)
     fun getInstance(): MastodonRequest<Instance> {
+        InstanceMethods::getInstance.requireMinVersion(client)
+
         return client.getMastodonRequest(
             endpoint = instanceEndpointV2,
             method = MastodonClient.Method.GET

--- a/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/testtool/MockClient.kt
@@ -21,7 +21,8 @@ object MockClient {
         maxId: String? = null,
         sinceId: String? = null,
         requestUrl: String = "https://example.com",
-        responseBaseUrl: String = "https://mstdn.jp/api/v1/timelines/public"
+        responseBaseUrl: String = "https://mstdn.jp/api/v1/timelines/public",
+        instanceVersion: String = "1337.42.23"
     ): MastodonClient {
         val clientMock: MastodonClient = mockk()
         val response: Response = Response.Builder()
@@ -59,11 +60,13 @@ object MockClient {
         every { clientMock.postRequestBody(any<String>(), any<RequestBody>()) } returns response
         every { clientMock.put(any<String>(), any<Parameters>()) } returns response
         every { clientMock.performAction(any<String>(), any<MastodonClient.Method>(), any<Parameters>()) } returns Unit
+        every { clientMock.getInstanceVersion() } returns instanceVersion
         return clientMock
     }
 
     fun ioException(
-        requestUrl: String = "https://example.com"
+        requestUrl: String = "https://example.com",
+        instanceVersion: String = "1337.42.23"
     ): MastodonClient {
         val clientMock: MastodonClient = mockk()
         val responseBodyMock: ResponseBody = mockk()
@@ -89,13 +92,15 @@ object MockClient {
                 any<Parameters>()
             )
         } throws BigBoneRequestException("mock")
+        every { clientMock.getInstanceVersion() } returns instanceVersion
         return clientMock
     }
 
     fun failWithResponse(
         responseJsonAssetPath: String,
         responseCode: Int,
-        message: String
+        message: String,
+        instanceVersion: String = "1337.42.23"
     ): MastodonClient {
         val clientMock: MastodonClient = mockk()
         val responseBodyMock: ResponseBody = mockk()
@@ -124,6 +129,7 @@ object MockClient {
                 any<Parameters>()
             )
         } throws BigBoneRequestException(response)
+        every { clientMock.getInstanceVersion() } returns instanceVersion
         return clientMock
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ junit-platform-suite-engine = { module = "org.junit.platform:junit-platform-suit
 kluent = { module = "org.amshove.kluent:kluent", version.ref = "kluent" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-dsl = { module = "io.mockk:mockk-dsl", version.ref = "mockk" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/sample-java/src/main/java/social/bigbone/sample/GetInstanceInfo.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetInstanceInfo.java
@@ -3,11 +3,12 @@ package social.bigbone.sample;
 import social.bigbone.MastodonClient;
 import social.bigbone.api.entity.Instance;
 import social.bigbone.api.exception.BigBoneRequestException;
+import social.bigbone.api.exception.BigBoneVersionException;
 
 @SuppressWarnings("PMD.SystemPrintln")
 public class GetInstanceInfo {
 
-    public static void main(final String[] args) throws BigBoneRequestException {
+    public static void main(final String[] args) throws BigBoneRequestException, BigBoneVersionException {
         final String instance = args[0];
 
         // Instantiate client


### PR DESCRIPTION
# Description

[Our Wiki](https://github.com/andregasser/bigbone/wiki/API-Support#method-signatures) mentions:

> All methods are annotated using a `@MastodonMinServerVersion` runtime annotation. The goal of this annotation is to specify the minimum server version that is required in order to make this call successful. During library initialization, we fetch the server version from the instance. When the method is invoked, we compare versions and if requirements are not met, we will throw a `BigBoneVersionException`. The caller can then decide how to proceed further (e.g. call another method or fail).

So far, that was not at all the case. But I like the idea, so I wanted to implement a proof of concept which is how this PR should be seen: Not a mergeable change set, but grounds for discussion.

I have added the annotation and additional functions to check if a called method’s min version is higher than or equal to the known instance version.

I’m currently not too happy with the `InstanceMethods::getInstance.requireMinVersion(client)` call and that would be my main criticism for the current solution. My knowledge regarding annotations, reflection, or annotation-based code is very much in its infancy so I’m sure there are better solutions that I’d still need to learn about. [`ksp`](https://github.com/google/ksp/) might be an option to auto-create the boilerplate code so that we only need to add the annotation and then ksp handles the rest for us and automatically adds code similar to what I’ve added for `getInstance` as an example for now.

Before I continue with this, I’d like to find out what you think of this. Is this a good way forward? Would you like a different approach?


# Type of Change

(Keep the one that applies, remove the rest)

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Dependency addition

## Breaking change

Methods annotated with `@MastodonMinServerVersion` may now throw a `BigBoneVersionException` which leads to errors from Java callers if they’re not explicitly handling that exception (or its parent `Exception`).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Mandatory Checklist

- [x] My change follows the projects coding style
- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] KDoc added to all public methods