### PR TITLE
Add section for breaking changes to pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,15 +6,19 @@ Please include a summary of the changes and the related issue. Please also inclu
 
 (Keep the one that applies, remove the rest)
 
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- This change requires a documentation update
+- Bug fix
+- New feature
+- Documentation
 - Dependency update / replacement
 
 # Breaking Changes
 
-If your change includes any breaking changes, please list them here, otherwise "None".
+A breaking change is a change to supported functionality between released versions of a library that would require 
+a customer to do work in order to upgrade to the newer version. If your change includes one or more breaking changes, 
+please list/document them here, otherwise set "None". This information will be published in our release notes.
+
+- Breaking change 1
+- ...
 
 # How Has This Been Tested?
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,6 +12,10 @@ Please include a summary of the changes and the related issue. Please also inclu
 - This change requires a documentation update
 - Dependency update / replacement
 
+# Breaking Changes
+
+If your change includes any breaking changes, please list them here, otherwise "None".
+
 # How Has This Been Tested?
 
 Please describe the tests that you ran to verify your changes. 


### PR DESCRIPTION
# Description

I have added a section for listing breaking changes that have been introduced as part of a pull request.

# Type of Change

- Documentation only

# How Has This Been Tested?

No tests executed - documentation only.

# Mandatory Checklist

- [x] My change follows the projects coding style
- [ ] I ran `gradle check` and there were no errors reported
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] KDoc added to all public methods

# Optional Things To Check

The items below are some more things to check before asking other people to review your code.

- In case you worked on new features: Did you also implement the reactive endpoint (bigbone-rx)?
- In case you added new *Methods classes: Did you also add it to `MastodonClient`?
- In case you worked on endpoints: Please mention in the PR that [API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage) page needs to be updated (if needed)
