### PR TITLE
Allow searches for individual types

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/SearchMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/SearchMethods.kt
@@ -1,5 +1,6 @@
 package social.bigbone.api.method
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import social.bigbone.MastodonClient
@@ -25,7 +26,10 @@ class SearchMethods(private val client: MastodonClient) {
         HASHTAGS,
 
         @SerialName("statuses")
-        STATUSES
+        STATUSES;
+
+        @OptIn(ExperimentalSerializationApi::class)
+        val apiName: String get() = serializer().descriptor.getElementName(ordinal)
     }
 
     /**
@@ -87,7 +91,7 @@ class SearchMethods(private val client: MastodonClient) {
                 append("exclude_unreviewed", true)
             }
             if (type != null) {
-                append("type", type.name)
+                append("type", type.apiName)
             }
             if (!accountId.isNullOrEmpty() && accountId.isNotBlank()) {
                 append("account_id", accountId)

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/SearchMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/SearchMethodsTest.kt
@@ -1,9 +1,14 @@
 package social.bigbone.api.method
 
+import io.mockk.slot
+import io.mockk.verify
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainAll
+import org.amshove.kluent.shouldNotContain
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import social.bigbone.Parameters
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
 
@@ -43,6 +48,25 @@ class SearchMethodsTest {
         result.statuses.size shouldBeEqualTo 4
         result.hashtags.size `should be equal to` 0
         result.statuses.all { it.id.toLong() in minId.toLong()..maxId.toLong() }
+    }
+
+    @Test
+    fun searchTypeParameterIsProperlyCapitalized() {
+        val client = MockClient.mock("search.json")
+        val searchMethodsMethod = SearchMethods(client)
+
+        searchMethodsMethod.searchContent("query", SearchMethods.SearchType.STATUSES).execute()
+        val parametersCapturingSlot = slot<Parameters>()
+        verify {
+            client.get(
+                path = "api/v2/search",
+                query = capture(parametersCapturingSlot)
+            )
+        }
+        with(parametersCapturingSlot.captured) {
+            parameters["type"]?.shouldContainAll(listOf("statuses"))
+            parameters["type"]?.shouldNotContain(listOf("STATUSES"))
+        }
     }
 
     @Test


### PR DESCRIPTION
# Description

- change searchContent() parameter "type" to use values understood by Mastodon server (was previously using uppercase instead of lowercase)
- add test failing for previous behaviour

Closes #343.

# Type of Change

(Keep the one that applies, remove the rest)

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

One test added to detect previously wrong behaviour that is now fixed

# Mandatory Checklist

- [X] My change follows the projects coding style
- [X] I ran `gradle check` and there were no errors reported
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] KDoc added to all public methods

# Optional Things To Check

The items below are some more things to check before asking other people to review your code.

- In case you worked on new features: Did you also implement the reactive endpoint (bigbone-rx)?
- In case you added new *Methods classes: Did you also add it to `MastodonClient`?
- In case you worked on endpoints: Please mention in the PR that [API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage) page needs to be updated (if needed)
