### PR TITLE
Clarify parameter interaction in searchContent method

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/method/SearchMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/SearchMethods.kt
@@ -34,6 +34,7 @@ class SearchMethods(private val client: MastodonClient) {
 
     /**
      * Search for content in accounts, statuses and hashtags.
+     * @see <a href="https://github.com/mastodon/documentation/issues/1336">Mastodon issue: incomplete documentation of offset/type parameters</a>
      * @param query string to search for
      * @param type to specify if you are looking for a specific typology
      * @param resolve whether to resolve non-local accounts
@@ -43,7 +44,7 @@ class SearchMethods(private val client: MastodonClient) {
      * @param maxId to return results whose id will be lesser than this one
      * @param minId to return results whose id will be newer than this one
      * @param limit to limit number of results within a range of 20-40 per category
-     * @param offset to skip the first n results
+     * @param offset to skip the first n results; only used if a type is specified
      * @see <a href="https://docs.joinmastodon.org/methods/search/">Mastodon API documentation: methods/search</a>
      */
     @JvmOverloads


### PR DESCRIPTION
# Description

- offset parameter will only be interpreted by Mastodon server if a type is specified; if not, default value of 0 will always be used by server
- this behaviour is currently not documented by Mastodon, see issue: https://github.com/mastodon/documentation/issues/1336

Closes #342.

# Type of Change

(Keep the one that applies, remove the rest)

- documentation update only

# How Has This Been Tested?

- no code changes

# Mandatory Checklist

- [X] My change follows the projects coding style
- [X] I ran `gradle check` and there were no errors reported
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] KDoc added to all public methods

# Optional Things To Check

The items below are some more things to check before asking other people to review your code.

- In case you worked on new features: Did you also implement the reactive endpoint (bigbone-rx)?
- In case you added new *Methods classes: Did you also add it to `MastodonClient`?
- In case you worked on endpoints: Please mention in the PR that [API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage) page needs to be updated (if needed)
