### PR TITLE
Update markdown documentation in the root folder of the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,65 +2,75 @@
 
 Welcome to the Code Contribution Guidelines for BigBone!
 
-This document provides important information for developers which are interested in contributing to BigBone. First of all, thank you for 
-taking an interest in the further development of this project. We want to make it as easy as possible for you to contribute to the project. 
-For this reason we have created this guide.
+This document provides important information for developers which are interested in contributing to BigBone. First of 
+all, thank you for taking an interest in the further development of this project. We want to make it as easy as possible
+for you to contribute to the project. For this reason we have created this guide.
 
 ## Getting Started
 
-In this section we will help you setup your machine for working on the project and also give you some ideas for finding tasks and/or issues
-you could contribute to.
+In this section we will help you set up your machine for working on the project and also give you some ideas for finding
+tasks and/or issues you could contribute to.
 
 ### Preparing Your Machine
 
-Before you can contribute work to the project, you need to setup your machine. For BigBone, this simply means, you should [clone the code
-repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) to a directory of your choice and 
-then run a `gradlew check` from within the root directory of the project to see if everything builds correctly and the tests run fine. We use 
-[Gradle](https://gradle.org/) to build the project. Don't worry if you do not have it installed on your machine, as it will be downloaded 
-automatically during the first build.
+Before you can contribute work to the project, you need to set up your machine. For BigBone, this simply means, you should 
+[clone the code repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) 
+to a directory of your choice and then run a `gradlew check` from within the root directory of the project to see if 
+everything builds correctly and the tests run fine. We use [Gradle](https://gradle.org/) to build the project. Don't 
+worry if you do not have it installed on your machine, as it will be downloaded automatically during the first build.
 
-Please also note that the project requires at least Java 8 in order to build successfully. But we don't think this is really an issue nowadays.
+Please also note that the project requires at least Java 8 in order to build successfully.
 
 ### Project Structure Overview
 
 The project comprises five primary Gradle modules:
 
 - **bigbone:** This module contains the core code for interacting with the Mastodon REST API, including tests.
-- **bigbone-rx:** This module serves as a thin layer built on top of the `bigbone` module. It exposes methods available in the `bigbone` module as RxJava3 types, allowing the use of this library within an RxJava context.
-- **buildSrc:** This section contains Gradle plugin code written in Groovy. Generally, you won't need to make changes here, as it's exclusively used for the build process. However, in specific cases, such as introducing a new dependency, you might need to make adjustments.
+- **bigbone-rx:** This module serves as a thin layer built on top of the `bigbone` module. It exposes methods available 
+  in the `bigbone` module as RxJava3 types, allowing the use of this library within an RxJava context.
+- **buildSrc:** This section contains Gradle plugin code written in Groovy. Generally, you won't need to make changes 
+  here, as it's exclusively used for the build process. However, in specific cases, such as introducing a new 
+  dependency, you might need to make adjustments.
 - **sample-java:** This module contains Java sample code that demonstrates the usage of BigBone.
 - **sample-kotlin:** Similar to sample-java, this module provides sample code written in Kotlin.
 
 Additionally, there are other folders within the project, including:
 
 - **config:** This folder houses tooling configurations for code analysis tools like PMD, Checkstyle, and Detekt.
-- **docker:** Here, you can find Docker Compose configurations for setting up a functional Mastodon instance. This instance is intended for running integration tests on a developer's local machine. While it essentially works, it may require further refinement to operate seamlessly.
+- **docker:** Here, you can find Docker Compose configurations for setting up a functional Mastodon instance. This 
+  instance is intended for running integration tests on a developer's local machine. While it essentially works, it may
+  require further refinement to operate seamlessly.
+- **docs:** Here we host the documentation that is published on https://bigbone.social.
 - **gradle:** This section contains the Gradle version catalog and wrapper configurations for the build process.
 - **.github:** Within this folder, you'll find GitHub workflow configurations and settings related to Dependabot.
 
 ### Find Something to Work On
 
-Now as everything is set up nicely on your local machine, it is time to find something for you to work on. Here are some ideas for you:
+Now as everything is set up nicely on your local machine, it is time to find something for you to work on. Here are some
+ideas for you:
 
-- **Good First Issues**: Check our [issue tracker](https://github.com/andregasser/bigbone/issues) for issues labeled `good first issue`. 
-  These are usually good tasks to get started and get into the project.
-- **Mastodon API Coverage**: Visit our [Mastodon API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage) page and look 
-  for entries highlighted in orange. These are endpoints that are not yet fully implemented. Most of the time there is a parameter missing that 
-  needs to be implemented. Alternatively you can also look for a red marked endpoint. These are endpoints that are not yet supported by BigBone.
-- **Improve Sample Code**: BigBone provides sample code in two of the modules (`sample-java` and `sample-kotlin`). You could contribute a new 
-  sample to the project which adds value for library users.
-- **Improve Test Coverage**: Our test coverage is not as good as it should be. There is quite some code which is not covered by tests yet. You
-  could add value by adding new tests to our library.
+- **Good First Issues**: Check our [issue tracker](https://github.com/andregasser/bigbone/issues) for issues labeled 
+  `good first issue`. These are usually good tasks to get started and get into the project.
+- **API Coverage**: Visit our [API Coverage](https://bigbone.social/api-coverage/) page and look for entries highlighted
+  in orange. These are endpoints that are not yet fully implemented. Most of the time there is a parameter missing that 
+  needs to be implemented. Alternatively you can also look for endpoints marked in red. These are endpoints that are not
+  yet supported by BigBone.
+- **Improve Sample Code**: BigBone provides sample code in two of the modules (`sample-java` and `sample-kotlin`). You 
+  could contribute a new sample to the project which adds value for library users.
+- **Improve Test Coverage**: Our test coverage is not as good as it should be. There is quite some code which is not 
+  covered by tests yet. You could add value by adding new tests to our library.
+- **Improve Documentation**: We host the project's documentation on https://bigbone.social. The source for this
+  documentation is located in the `/docs` folder. Try to improve the documentation by creating a pull request.
 
 Of course, we're also open for other types of contributions. Plus: Every contribution counts, even if it is a small one.
 
-Make sure you let us know that you are working on an issue. Ideally, there's an issue in our issue tracker already which you can simply assign
-to yourself. If not, feel free to open a new issue.
+Make sure you let us know that you are working on an issue. Ideally, there's an issue in our issue tracker already which
+you can simply assign to yourself. If not, feel free to open a new issue.
 
 ### Create a Feature Branch
 
-Go to your local directory into which you have cloned our repository. You should be on the `master` branch. Create a new feature branch for your
-work. You can use the following command for this:
+Go to your local directory into which you have cloned our repository. You should be on the `master` branch. Create a new
+feature branch for your work. You can use the following command for this:
 
 ```bash
 $ git checkout -b feature/my-awesome-contribution
@@ -70,41 +80,42 @@ You can now work on your contribution, congrats!
 
 ### When You Get Stuck
 
-Whenever you get stuck while trying to contribute to the project, you can reach out to BigBone developers. Please use one of the channels listed
-below as they provide maximum transparency for the project and it allows us to keep a good historical record of communication. 
+Whenever you get stuck while trying to contribute to the project, you can reach out to BigBone developers. Please use 
+one of the channels listed below as they provide maximum transparency for the project and it allows us to keep a good 
+historical record of communication. 
 
-- **Slack**: BigBone developers use [Slack](https://github.com/andregasser/bigbone/discussions/151) to coordinate work between developers. We
-  would appreciate it, if you join our `#bigbone-development` channel. Also, it allows you to reach individual developers directly.
-- **GitHub Issues**: If you are working on an existing GitHub issue, feel free to discuss your problems on that issue itself.
+- **Slack**: BigBone developers use [Slack](https://github.com/andregasser/bigbone/discussions/151) to coordinate work 
+  between developers. We would appreciate it, if you join our `#bigbone-development` channel. Also, it allows you to 
+  reach individual developers directly.
+- **GitHub Issues**: If you are working on an existing GitHub issue, feel free to discuss your problems on that issue 
+  itself.
 - **GitHub Discussions**: If you would like to discuss a topic, feel free to open a new discussion thread.
 
-BigBone is developed and maintained by volunteers in their spare time. Therefore, we cannot guarantee response times or the like. We do not 
-offer professional support for this library. Support is always best effort and sometimes it can take longer because nobody has time. This is 
-just how it is. Thank you for your understanding.
+BigBone is developed and maintained by volunteers in their spare time. Therefore, we cannot guarantee response times or 
+the like. We do not offer professional support for this library. Support is always best effort and sometimes it can take
+longer because nobody has time. This is just how it is. Thank you for your understanding.
 
 ## Submit Your First Contribution
 
-Congratulations! Your first contribution is ready for submission. But before you do that, we would like to ask you to check a few 
-things before you move forward. This is to ensure that your changes can be integrated into our project without problems.
+Congratulations! Your first contribution is ready for submission. But before you do that, we would like to ask you to 
+check a few things before you move forward. This is to ensure that your changes can be integrated into our project 
+without problems.
 
-- Run 'gradlew check' locally on your changes and make sure that no issues are reported
+- When you open a new pull request, we automatically provide a pull request template text that you can fill out/modify. 
+  It contains checklists to go through in order to make sure you do not forget important things. Please make use of it.
 - Give your pull request a meaningful name as we use this in our release notes (e.g. "Add support for favourites API")
-- If your pull request closes any existing issues, please link those issues in the pull request description (e.g. "Closes #193", where
-  #193 is linked to issue 193).
-- Also make sure your changes are covered by tests if possible.
-- Ensure that documentation is up-to-date. Have a look at similar classes in the project and try to align your code with ours.
-- Please compact the changes you submit into a single commit (you can squash commits locally using git). We try to keep a clean timeline
-  on the `master` branch.
+- Please compact the changes you submit into a single commit (you can squash commits locally using git). We try to keep 
+  a clean timeline on the `master` branch.
 - Your pull request should target our `master` branch.
 
-Once you have opened the pull request, we will review your changes. Please be patient and make sure, you have project notifications
-turned on, ensuring you get notified when someone adds a comment to your contribution.  
+Once you have opened the pull request, we will review your changes. Please be patient and make sure, you have project 
+notifications turned on, ensuring you get notified when someone adds a comment to your contribution.  
 
 ## Report an Issue
 
-We use GitHub issues to track issues. Whenever you find an issue in our library, whether it is a problem in the code or in the documentation,
-please [open a new issue](https://github.com/andregasser/bigbone/issues). Make sure you provide as much information as possible. It 
-should be possible for us to reproduce the issue easily. Great issue reports have:
+We use GitHub issues to track issues. Whenever you find an issue in our library, whether it is a problem in the code or 
+in the documentation, please [open a new issue](https://github.com/andregasser/bigbone/issues). Make sure you provide as
+much information as possible. It should be possible for us to reproduce the issue easily. Great issue reports have:
 
 - A quick summary and/or background
 - Steps to reproduce

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ abandoned and has not seen any updates since 2018.
 Since Elon Musk's Twitter acquisition in 2022, Mastodon has gained tremendous popularity. A project that is so well 
 received by the community deserves to have up-to-date and maintained client libraries. Because of this, we brought the 
 Mastodon4J project back to life in November 2022. That's when this project, the BigBone client library for Java and 
-Kotlin, was born. May it serve you well in your Mastodon-related endeavours!
+the BigBone client library for Java and Kotlin, was born.
 
-The name **BigBone** has mostly symbolic character. We have chosen the name BigBone for this library because Mastodons 
-represent impressive animals from the Pleistocene, built of big and heavy bones. At the same time, we hope this library 
-will build some sort of "skeleton" for your Mastodon-related projects. Interestingly, there is also 
-[Big Bone Lick State Park in Kentucky](https://parks.ky.gov/union/parks/historic/big-bone-lick-state-historic-site) 
-where American Mastodons have been excavated.
+The name **BigBone** mostly has symbolic character. We opted for it as a nod to the awe-inspiring Mastodons of the Pleistocene era,
+characterised by their robust and colossal bones. We envision this library serving as a foundational _skeleton_ for your Mastodon-related projects.
+Fun fact: There’s also [Big Bone Lick State Park in Kentucky](https://parks.ky.gov/union/parks/historic/big-bone-lick-state-historic-site),
+a site where American Mastodons were excavated.
+May the BigBone library be as enduring and impactful as its namesake, providing strength and structure to your Mastodon endeavours.
 
 # Project Team
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 **BigBone** is a [Mastodon](https://docs.joinmastodon.org/) client library for Java and Kotlin.
 
-Maintained and developed with love by [André Gasser](https://fosstodon.org/@andregasser) and [contributors](https://github.com/andregasser/bigbone/graphs/contributors).
-
 # Table of Contents
 * [Why BigBone](#why-bigbone)
 * [Core Functionality](#core-functionality)
@@ -41,6 +39,17 @@ will build some sort of "skeleton" for your Mastodon-related projects. Interesti
 [Big Bone Lick State Park in Kentucky](https://parks.ky.gov/union/parks/historic/big-bone-lick-state-historic-site) 
 where American Mastodons have been excavated.
 
+# Project Team
+
+The project is currently taken care of by the following people:
+
+- [André Gasser](https://fosstodon.org/@andregasser)
+- [Andreas Bartels](https://fosstodon.org/@bocops)
+- [Patrick Geselbracht](@PattaFeuFeu@chaos.social)
+
+A big "Thank you" to everyone for the time they invest in this project. Without your help we would not be where we are 
+right now. 
+
 # Core Functionality
 
 With a library like BigBone, you can build tools that allow you to
@@ -53,6 +62,7 @@ With a library like BigBone, you can build tools that allow you to
 - send direct messages to other people
 - manage filters
 - follow/unfollow hashtags
+- administer your Mastodon instance
 - plus lots of other stuff!
 
 # Implementation Status

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 # Table of Contents
 * [Why BigBone](#why-bigbone)
+* [Project Team](#project-team)
 * [Core Functionality](#core-functionality)
 * [Implementation Status](#implementation-status)
 * [Versioning](#versioning)

--- a/README.md
+++ b/README.md
@@ -25,18 +25,21 @@ Maintained and developed with love by [André Gasser](https://fosstodon.org/@and
 
 # Why BigBone
 
-BigBone is a fork of [Mastodon4J](https://github.com/sys1yagi/mastodon4j), a Mastodon client library for Java and Kotlin that was published by Toshihiro Yagi. 
-The goal of Mastodon4J was to provide an easy-to-use library for interacting with the [Mastodon social media network](https://joinmastodon.org/) from Java and 
-Kotlin code. Unfortunately, it became abandoned and has not seen any updates since 2018. 
+BigBone is a fork of [Mastodon4J](https://github.com/sys1yagi/mastodon4j), a Mastodon client library for Java and Kotlin
+that was published by Toshihiro Yagi. The goal of Mastodon4J was to provide an easy-to-use library for interacting with 
+the [Mastodon social media network](https://joinmastodon.org/) from Java and Kotlin code. Unfortunately, it became 
+abandoned and has not seen any updates since 2018. 
 
-Since Elon Musk's Twitter acquisition in 2022, Mastodon has gained tremendous popularity. A project that is so well received by the community deserves to have 
-up-to-date and maintained client libraries. Because of this, we brought the Mastodon4J project back to life in November 2022. That's when this project,
-the BigBone client library for Java and Kotlin, was born. May it serve you well in your Mastodon-related endeavours!
+Since Elon Musk's Twitter acquisition in 2022, Mastodon has gained tremendous popularity. A project that is so well 
+received by the community deserves to have up-to-date and maintained client libraries. Because of this, we brought the 
+Mastodon4J project back to life in November 2022. That's when this project, the BigBone client library for Java and 
+Kotlin, was born. May it serve you well in your Mastodon-related endeavours!
 
-The name **BigBone** has mostly symbolic character. We have chosen the name BigBone for this library because Mastodons represent impressive animals from the 
-Pleistocene, built of big and heavy bones. At the same time, we hope this library will build some sort of "skeleton" for your Mastodon-related projects. 
-Interestingly, there is also [Big Bone Lick State Park in Kentucky](https://parks.ky.gov/union/parks/historic/big-bone-lick-state-historic-site) where 
-American Mastodons have been excavated.
+The name **BigBone** has mostly symbolic character. We have chosen the name BigBone for this library because Mastodons 
+represent impressive animals from the Pleistocene, built of big and heavy bones. At the same time, we hope this library 
+will build some sort of "skeleton" for your Mastodon-related projects. Interestingly, there is also 
+[Big Bone Lick State Park in Kentucky](https://parks.ky.gov/union/parks/historic/big-bone-lick-state-historic-site) 
+where American Mastodons have been excavated.
 
 # Core Functionality
 
@@ -54,12 +57,13 @@ With a library like BigBone, you can build tools that allow you to
 
 # Implementation Status
 
-**We did not release an official version on Maven Central yet**, but there's a `2.0.0-SNAPSHOT` which you can use to play around / experiment with. 
-Just please be aware that with every new snapshot version, there can be breaking changes along the lines. There will be "darker places" in the 
-library, where stuff will not work as expected. If you find issues, please [file an issue](https://github.com/andregasser/bigbone/issues).  
+**We did not release an official version on Maven Central yet**, but there's a `2.0.0-SNAPSHOT` which you can use to 
+play around / experiment with. Just please be aware that with every new snapshot version, there can be breaking changes 
+along the lines. There will be "darker places" in the library, where stuff will not work as expected. If you find 
+issues, please [file an issue](https://github.com/andregasser/bigbone/issues).  
 
-BigBone does not yet implement the full API of Mastodon. Actually, there is still **a lot to do**. For details on the current API coverage 
-please check out our wiki page [Mastodon API Coverage](https://github.com/andregasser/bigbone/wiki/Mastodon-API-Coverage).
+BigBone does not yet implement the full API of Mastodon. Actually, there is still **a lot to do**. For details on the 
+current API coverage please check out our [API Coverage](https://bigbone.social/api-coverage/) page.
 
 # Versioning
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ where American Mastodons have been excavated.
 
 The project is currently taken care of by the following people:
 
-- [André Gasser](https://fosstodon.org/@andregasser)
-- [Andreas Bartels](https://fosstodon.org/@bocops)
-- [Patrick Geselbracht](@PattaFeuFeu@chaos.social)
+- [André Gasser](https://github.com/andregasser/)
+- [Andreas Bartels](https://github.com/bocops)
+- [Patrick Geselbracht](https://github.com/PattaFeuFeu)
 
 A big "Thank you" to everyone for the time they invest in this project. Without your help we would not be where we are 
 right now. 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,22 +1,24 @@
 # BigBone Support
 
-This document provides information on how to get support for BigBone from a library user perspective. If you are a contributor
-to the project, please check out our [Code Contribution Guidelines](CONTRIBUTING.md).
+This document provides information on how to get support for BigBone from a library user perspective. If you are a 
+contributor to the project, please check out our [Code Contribution Guidelines](CONTRIBUTING.md).
 
 ## Support Channels
 
-You can communicate with us through different ways. We prefer open communication and therefore deliberately avoid email support. 
-We value transparency and traceability. For this reason, we limit ourselves to the channels below.
+You can communicate with us through different ways. We prefer open communication and therefore deliberately avoid email 
+support. We value transparency and traceability. For this reason, we limit ourselves to the channels below.
 
 ### GitHub Issues
 
-If you have found a bug or want to submit a request for a new feature, please [open an issue](https://github.com/andregasser/bigbone/issues).
-Please make sure that you create an accurate problem description that allows us to reproduce the issue.
+If you have found a bug or want to submit a request for a new feature, please 
+[open an issue](https://github.com/andregasser/bigbone/issues). Please make sure that you create an accurate problem 
+description that allows us to reproduce the issue.
 
 ### GitHub Discussions
 
-If you have a question about using BigBone or other topics that are not necessarily considered issues, please [open a discussion thread](https://github.com/andregasser/bigbone/discussions). 
-We will try to help you as good as possible. If necessary, we can open an issue for this after, if needed.
+If you have a question about using BigBone or other topics that are not necessarily considered issues, please 
+[open a discussion thread](https://github.com/andregasser/bigbone/discussions). We will try to help you as good as 
+possible. If necessary, we can open an issue for this after, if needed.
 
 ## Managing Expectations
 


### PR DESCRIPTION
# Description

Updated the markdown files in the root folder of the project. They contained outdated links to the API Coverage page. Also improved the README.md a bit by adding some additional info. Reformatted the files to fit the 120 characters per line limit. Because of this, lots of lines are highlighted as changed in the PR. Will add some comments to highlight the real content changes.

# Type of Change

- Documentation

# Breaking Changes

None.

# How Has This Been Tested?

Not tested.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods

# Optional Things To Check

The items below are some more things to check before asking other people to review your code.

- In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
- In case you added new `*Methods` classes: Did you also reference it in the `MastodonClient` main class?
- Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?
