### PR TITLE
Remove defaults for limit parameter + do not verify values

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAccountMethods.kt
@@ -91,7 +91,7 @@ class RxAccountMethods(client: MastodonClient) {
     }
 
     @JvmOverloads
-    fun searchAccounts(query: String, limit: Int = 40): Single<List<Account>> = Single.fromCallable {
+    fun searchAccounts(query: String, limit: Int? = null): Single<List<Account>> = Single.fromCallable {
         accountMethods.searchAccounts(query, limit).execute()
     }
 }

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxDirectoryMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxDirectoryMethods.kt
@@ -19,7 +19,7 @@ class RxDirectoryMethods(client: MastodonClient) {
         local: Boolean,
         order: DirectoryMethods.AccountOrder = DirectoryMethods.AccountOrder.ACTIVE,
         offset: Int = 0,
-        limit: Int = 40
+        limit: Int? = null
     ): Single<List<Account>> = Single.fromCallable {
         directoryMethods.listAccounts(local, order, offset, limit).execute()
     }

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxDomainBlockMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxDomainBlockMethods.kt
@@ -23,8 +23,9 @@ class RxDomainBlockMethods(client: MastodonClient) {
      * @return
      */
     @JvmOverloads
-    fun getDomainBlocks(range: Range = Range()): Single<Pageable<String>> =
-        Single.fromCallable { domainBlockMethods.getDomainBlocks(range).execute() }
+    fun getDomainBlocks(range: Range = Range()): Single<Pageable<String>> = Single.fromCallable {
+        domainBlockMethods.getDomainBlocks(range).execute()
+    }
 
     /**
      * Block a domain to hide all public posts from it, hide all notifications from it,
@@ -41,6 +42,5 @@ class RxDomainBlockMethods(client: MastodonClient) {
      * @param domain Domain to block
      * @see <a href="https://docs.joinmastodon.org/methods/domain_blocks/#block">Mastodon API documentation: methods/domain_blocks/#block</a>
      */
-    fun unblockDomain(domain: String): Completable =
-        Completable.fromAction { domainBlockMethods.unblockDomain(domain) }
+    fun unblockDomain(domain: String): Completable = Completable.fromAction { domainBlockMethods.unblockDomain(domain) }
 }

--- a/bigbone-rx/src/test/kotlin/social/bigbone/rx/RxEndorsementMethodsTest.kt
+++ b/bigbone-rx/src/test/kotlin/social/bigbone/rx/RxEndorsementMethodsTest.kt
@@ -2,7 +2,6 @@ package social.bigbone.rx
 
 import org.junit.jupiter.api.Test
 import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.rx.testtool.MockClient
 
@@ -21,26 +20,6 @@ class RxEndorsementMethodsTest {
 
             assertValueCount(1)
             assertValue { endorsements: Pageable<Account> -> endorsements.part.size == 2 }
-
-            dispose()
-        }
-    }
-
-    @Test
-    fun `Given a client returning success, when getting endorsements with limit of 90, then emit error`() {
-        val client = MockClient.mock(
-            jsonName = "endorsements_view_success.json"
-        )
-        val endorsements = RxEndorsementMethods(client)
-
-        with(endorsements.getEndorsements(range = Range(limit = 90)).test()) {
-            assertNoValues()
-            assertNotComplete()
-
-            assertError { error: Throwable ->
-                error is IllegalArgumentException &&
-                    error.message == "limit defined in Range must not be higher than 80 but was 90"
-            }
 
             dispose()
         }

--- a/bigbone/src/main/kotlin/social/bigbone/api/Range.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Range.kt
@@ -12,9 +12,9 @@ class Range @JvmOverloads constructor(
     val limit: Int? = null
 ) {
     fun toParameters() = Parameters().apply {
-        maxId?.let { append("max_id", it) }
-        minId?.let { append("min_id", it) }
-        sinceId?.let { append("since_id", it) }
-        limit?.let { append("limit", it) }
+        maxId?.let { append("max_id", maxId) }
+        minId?.let { append("min_id", minId) }
+        sinceId?.let { append("since_id", sinceId) }
+        limit?.let { append("limit", limit) }
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AccountMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AccountMethods.kt
@@ -80,7 +80,12 @@ class AccountMethods(private val client: MastodonClient) {
      *  (e.g. data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...)
      * @see <a href="https://docs.joinmastodon.org/methods/accounts/#update_credentials">Mastodon API documentation: methods/accounts/#update_credentials</a>
      */
-    fun updateCredentials(displayName: String?, note: String?, avatar: String?, header: String?): MastodonRequest<Account> {
+    fun updateCredentials(
+        displayName: String?,
+        note: String?,
+        avatar: String?,
+        header: String?
+    ): MastodonRequest<Account> {
         return client.getMastodonRequest(
             endpoint = "api/v1/accounts/update_credentials",
             method = MastodonClient.Method.PATCH,
@@ -243,13 +248,17 @@ class AccountMethods(private val client: MastodonClient) {
      * @see <a href="https://docs.joinmastodon.org/methods/accounts/#search">Mastodon API documentation: methods/accounts/#search</a>
      */
     @JvmOverloads
-    fun searchAccounts(query: String, limit: Int = 40): MastodonRequest<List<Account>> {
+    fun searchAccounts(
+        query: String,
+        limit: Int? = null
+    ): MastodonRequest<List<Account>> {
         return client.getMastodonRequestForList(
             endpoint = "api/v1/accounts/search",
             method = MastodonClient.Method.GET,
-            parameters = Parameters()
-                .append("q", query)
-                .append("limit", limit)
+            parameters = Parameters().apply {
+                append("q", query)
+                limit?.let { append("limit", limit) }
+            }
         )
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/DirectoryMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/DirectoryMethods.kt
@@ -34,7 +34,7 @@ class DirectoryMethods(private val client: MastodonClient) {
         local: Boolean,
         order: AccountOrder = AccountOrder.ACTIVE,
         offset: Int = 0,
-        limit: Int = 40
+        limit: Int? = null
     ): MastodonRequest<List<Account>> {
         return client.getMastodonRequestForList(
             endpoint = "api/v1/directory",
@@ -46,7 +46,7 @@ class DirectoryMethods(private val client: MastodonClient) {
                     AccountOrder.NEW -> append("order", "new")
                 }
                 append("offset", offset)
-                append("limit", limit)
+                limit?.let { append("limit", limit) }
             }
         )
     }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/DomainBlockMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/DomainBlockMethods.kt
@@ -5,8 +5,6 @@ import social.bigbone.MastodonRequest
 import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 
-private const val QUERY_RESULT_LIMIT: Int = 200
-
 /**
  * Manage a user's blocked domains.
  * @see <a href="https://docs.joinmastodon.org/methods/domain_blocks/">Mastodon domain_blocks API methods</a>
@@ -19,20 +17,12 @@ class DomainBlockMethods(private val client: MastodonClient) {
      * View domains the user has blocked.
      * @param range optional Range for the pageable return value
      * @see <a href="https://docs.joinmastodon.org/methods/domain_blocks/#get">Mastodon API documentation: methods/domain_blocks/#get</a>
-     * @throws [IllegalArgumentException] if [range]'s [Range.limit] is larger than [QUERY_RESULT_LIMIT]
      * @return [Pageable] of [String] representing the domains the user has blocked
      */
     @JvmOverloads
-    @Throws(IllegalArgumentException::class)
     fun getDomainBlocks(
         range: Range = Range()
     ): MastodonRequest<Pageable<String>> {
-        if (range.limit != null && range.limit > QUERY_RESULT_LIMIT) {
-            throw IllegalArgumentException(
-                "limit defined in Range must not be higher than $QUERY_RESULT_LIMIT but was ${range.limit}"
-            )
-        }
-
         return client.getPageableMastodonRequest<String>(
             endpoint = domainBlocksEndpoint,
             method = MastodonClient.Method.GET,

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/EndorsementMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/EndorsementMethods.kt
@@ -6,8 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 
-private const val QUERY_RESULT_LIMIT: Int = 80
-
 /**
  * Feature other profiles on your own profile. See also accounts/:id/{pin,unpin}.
  * @see <a href="https://docs.joinmastodon.org/methods/endorsements/">Mastodon endorsement API methods</a>
@@ -21,19 +19,11 @@ class EndorsementMethods(private val client: MastodonClient) {
      * @param range optional Range for the pageable return value
      * @see <a href="https://docs.joinmastodon.org/methods/endorsements/#get">Mastodon API documentation: methods/endorsements/#get</a>
      * @return [Pageable] of [Account]s the user is currently featuring on their profile
-     * @throws [IllegalArgumentException] if [range]'s [Range.limit] is larger than [QUERY_RESULT_LIMIT]
      */
     @JvmOverloads
-    @Throws(IllegalArgumentException::class)
     fun getEndorsements(
         range: Range = Range()
     ): MastodonRequest<Pageable<Account>> {
-        if (range.limit != null && range.limit > QUERY_RESULT_LIMIT) {
-            throw IllegalArgumentException(
-                "limit defined in Range must not be higher than $QUERY_RESULT_LIMIT but was ${range.limit}"
-            )
-        }
-
         return client.getPageableMastodonRequest<Account>(
             endpoint = endorsementsEndpoint,
             method = MastodonClient.Method.GET,

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/FollowedTagMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/FollowedTagMethods.kt
@@ -6,8 +6,6 @@ import social.bigbone.api.Pageable
 import social.bigbone.api.Range
 import social.bigbone.api.entity.Tag
 
-private const val QUERY_RESULT_LIMIT = 200
-
 /**
  * Allows access to API methods with endpoints having an "api/vX/followed_tags" prefix.
  * View your followed hashtags.
@@ -25,12 +23,6 @@ class FollowedTagMethods(private val client: MastodonClient) {
      */
     @JvmOverloads
     fun viewAllFollowedTags(range: Range = Range()): MastodonRequest<Pageable<Tag>> {
-        with(range) {
-            if (limit != null && (limit <= 0 || limit > QUERY_RESULT_LIMIT)) {
-                throw IllegalArgumentException("Limit param must be between 0 and $QUERY_RESULT_LIMIT but was $limit")
-            }
-        }
-
         return client.getPageableMastodonRequest<Tag>(
             endpoint = followedTagsEndpoint,
             method = MastodonClient.Method.GET,

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/SuggestionMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/SuggestionMethods.kt
@@ -20,9 +20,6 @@ class SuggestionMethods(private val client: MastodonClient) {
      * @see <a href="https://docs.joinmastodon.org/methods/suggestions/#v2">Mastodon API documentation: methods/suggestions/#v2</a>
      */
     fun getSuggestions(limit: Int? = null): MastodonRequest<List<Suggestion>> {
-        if (limit != null && (limit <= 0 || limit > QUERY_RESULT_LIMIT)) {
-            throw IllegalArgumentException("Limit param must be greater than zero and not be higher than $QUERY_RESULT_LIMIT but was $limit")
-        }
         return client.getMastodonRequestForList(
             endpoint = suggestionsEndpointV2,
             method = MastodonClient.Method.GET,
@@ -42,9 +39,5 @@ class SuggestionMethods(private val client: MastodonClient) {
             endpoint = "$suggestionsEndpointV1/$accountId",
             method = MastodonClient.Method.DELETE
         )
-    }
-
-    companion object {
-        private const val QUERY_RESULT_LIMIT = 80
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/DomainBlockMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/DomainBlockMethodsTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import social.bigbone.MastodonClient
 import social.bigbone.Parameters
 import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
 
@@ -34,17 +33,6 @@ class DomainBlockMethodsTest {
                 query = any<Parameters>()
             )
         }
-    }
-
-    @Test
-    fun `Given a client returning success, when getting blocked domains with a limit of 210, then throw IllegalArgumentException`() {
-        val client = MockClient.mock("domain_blocks_view_success.json")
-
-        invoking {
-            DomainBlockMethods(client).getDomainBlocks(
-                range = Range(limit = 210)
-            ).execute()
-        } shouldThrow IllegalArgumentException::class withMessage "limit defined in Range must not be higher than 200 but was 210"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/EndorsementMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/EndorsementMethodsTest.kt
@@ -7,7 +7,6 @@ import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
 import social.bigbone.PrecisionDateTime.ValidPrecisionDateTime.ExactTime
 import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Account
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
@@ -38,17 +37,6 @@ class EndorsementMethodsTest {
         secondEndorsement.statusesCount shouldBeEqualTo 5906
         secondEndorsement.lastStatusAt shouldBeEqualTo ExactTime(Instant.parse("2019-11-23T05:23:47.911Z"))
         secondEndorsement.emojis.isEmpty() shouldBeEqualTo false
-    }
-
-    @Test
-    fun `Given a client returning success, when getting endorsements with a limit of 90, then throw IllegalArgumentException`() {
-        val client = MockClient.mock("endorsements_view_success.json")
-
-        invoking {
-            EndorsementMethods(client).getEndorsements(
-                range = Range(limit = 90)
-            ).execute()
-        } shouldThrow IllegalArgumentException::class withMessage "limit defined in Range must not be higher than 80 but was 90"
     }
 
     @Test

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/FollowedTagMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/FollowedTagMethodsTest.kt
@@ -1,17 +1,13 @@
 package social.bigbone.api.method
 
 import io.mockk.verify
-import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldHaveSize
 import org.amshove.kluent.shouldNotBeNull
-import org.amshove.kluent.shouldThrow
-import org.amshove.kluent.withMessage
 import org.junit.jupiter.api.Test
 import social.bigbone.Parameters
 import social.bigbone.api.Pageable
-import social.bigbone.api.Range
 import social.bigbone.api.entity.Tag
 import social.bigbone.testtool.MockClient
 
@@ -47,15 +43,5 @@ class FollowedTagMethodsTest {
                 query = any<Parameters>()
             )
         }
-    }
-
-    @Test
-    fun `Given a client returning success, when viewing all followed tags with too high a range limit, then throw exception on client side`() {
-        val client = MockClient.mock("followed_tags_view_all_followed_tags_success.json")
-        val followedTagMethods = FollowedTagMethods(client)
-
-        invoking {
-            followedTagMethods.viewAllFollowedTags(Range(limit = 300)).execute()
-        } shouldThrow java.lang.IllegalArgumentException::class withMessage "Limit param must be between 0 and 200 but was 300"
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/SuggestionMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/SuggestionMethodsTest.kt
@@ -28,13 +28,4 @@ class SuggestionMethodsTest {
             suggestionMethods.removeSuggestion("accountId")
         }
     }
-
-    @Test
-    fun overRangedLimitValueThrowsException() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            val client = MockClient.ioException()
-            val suggestionMethods = SuggestionMethods(client)
-            suggestionMethods.getSuggestions(100).execute()
-        }
-    }
 }


### PR DESCRIPTION
# Description

As discussed in #293 and #366, we should neither set default limits in our code, nor have client-side error handling for limit values. @bocops found out that in the Mastodon server code, `limit` values are just coerced into valid values anyway, so we won’t get an error anyway.

Removing both default limits and removing client-side validation for them ensures that we won’t have to update the library just because limit boundaries changed in some version of the Mastodon server code.

Closes #366

# Type of Change

- Bug fix

# Breaking Changes

- The following no longer throw or declare an `IllegalArgumentException`, so any try/catch can be removed:
  - `DomainBlockMethods#getDomainBlocks`
  - `EndorsementMethods#getEndorsements`
  - `FollowedTagMethods#viewAllFollowedTags`
  - `SuggestionMethods#getSuggestions`

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods