### PR TITLE
lists: Add “exclusive” parameter for full support

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxListMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxListMethods.kt
@@ -41,7 +41,7 @@ class RxListMethods(client: MastodonClient) {
     @JvmOverloads
     fun createList(
         title: String,
-        repliesPolicy: MastodonList.RepliesPolicy = MastodonList.RepliesPolicy.LIST,
+        repliesPolicy: MastodonList.RepliesPolicy? = null,
         exclusive: Boolean? = null
     ): Single<MastodonList> = Single.fromCallable { listMethods.createList(title, repliesPolicy, exclusive).execute() }
 

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxListMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxListMethods.kt
@@ -35,13 +35,15 @@ class RxListMethods(client: MastodonClient) {
      * Create a new list.
      * @param title The title of the list to be created.
      * @param repliesPolicy One of [MastodonList.RepliesPolicy], defaults to [MastodonList.RepliesPolicy.List].
+     * @param exclusive Whether members of this list need to get removed from the “Home” feed.
      * @see <a href="https://docs.joinmastodon.org/methods/lists/#create">Mastodon API documentation: methods/lists/#create</a>
      */
     @JvmOverloads
     fun createList(
         title: String,
-        repliesPolicy: MastodonList.RepliesPolicy = MastodonList.RepliesPolicy.LIST
-    ): Single<MastodonList> = Single.fromCallable { listMethods.createList(title, repliesPolicy).execute() }
+        repliesPolicy: MastodonList.RepliesPolicy = MastodonList.RepliesPolicy.LIST,
+        exclusive: Boolean? = null
+    ): Single<MastodonList> = Single.fromCallable { listMethods.createList(title, repliesPolicy, exclusive).execute() }
 
     /**
      * Change the title of a list, or which replies to show.

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/ListMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/ListMethods.kt
@@ -47,7 +47,7 @@ class ListMethods(private val client: MastodonClient) {
     @JvmOverloads
     fun createList(
         title: String,
-        repliesPolicy: MastodonList.RepliesPolicy = MastodonList.RepliesPolicy.LIST,
+        repliesPolicy: MastodonList.RepliesPolicy? = null,
         exclusive: Boolean? = null
     ): MastodonRequest<MastodonList> {
         return client.getMastodonRequest(
@@ -55,7 +55,7 @@ class ListMethods(private val client: MastodonClient) {
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("title", title)
-                append("replies_policy", repliesPolicy.name.lowercase())
+                repliesPolicy?.let { append("replies_policy", repliesPolicy.name.lowercase()) }
                 exclusive?.let { append("exclusive", exclusive) }
             }
         )

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/ListMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/ListMethods.kt
@@ -41,12 +41,14 @@ class ListMethods(private val client: MastodonClient) {
      * Create a new list.
      * @param title The title of the list to be created.
      * @param repliesPolicy One of [MastodonList.RepliesPolicy], defaults to [MastodonList.RepliesPolicy.List].
+     * @param exclusive Whether members of this list need to get removed from the “Home” feed.
      * @see <a href="https://docs.joinmastodon.org/methods/lists/#create">Mastodon API documentation: methods/lists/#create</a>
      */
     @JvmOverloads
     fun createList(
         title: String,
-        repliesPolicy: MastodonList.RepliesPolicy = MastodonList.RepliesPolicy.LIST
+        repliesPolicy: MastodonList.RepliesPolicy = MastodonList.RepliesPolicy.LIST,
+        exclusive: Boolean? = null
     ): MastodonRequest<MastodonList> {
         return client.getMastodonRequest(
             endpoint = "api/v1/lists",
@@ -54,6 +56,7 @@ class ListMethods(private val client: MastodonClient) {
             parameters = Parameters().apply {
                 append("title", title)
                 append("replies_policy", repliesPolicy.name.lowercase())
+                exclusive?.let { append("exclusive", exclusive) }
             }
         )
     }

--- a/docs/api-coverage/lists.md
+++ b/docs/api-coverage/lists.md
@@ -29,8 +29,8 @@ View and manage lists. See also: /api/v1/timelines/list/id for loading a list ti
   </tr>
   <tr>
     <td style="width:45%;text-align:left;"><code>POST /api/v1/lists</code><br>Create a list</td>
-    <td style="width:10%;text-align:center;"><img src="/assets/orange16.png"></td>
-    <td style="width:45%;text-align:left;">Property <code>exclusive</code> is missing which determines “whether members of this list need to get removed from the ‘Home’ feed”</td>
+    <td style="width:10%;text-align:center;"><img src="/assets/green16.png"></td>
+    <td style="width:45%;text-align:left;">Fully supported.</td>
   </tr>
   <tr>
     <td style="width:45%;text-align:left;"><code>PUT /api/v1/lists/:id</code><br>Update a list</td>


### PR DESCRIPTION
# Description

Updates the last remaining not fully supported function in the lists methods.

This adds the `exclusive` parameter to it which determines whether members of this list need to get removed from the “Home” feed.

I also made `repliesPolicy` a nullable value with `null` as the default instead of defining the default imposed by the Mastodon API locally.

# Type of Change

- New feature
- Documentation

# Breaking Changes

- `ListMethods#createList` parameter `repliesPolicy` now is `null` by default and is defined as nullable. Likely won’t break anything, but just in case…

# How Has This Been Tested?

I have not tested this change.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods

# Optional Things To Check

The items below are some more things to check before asking other people to review your code.

- [x] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)? 
- [x] Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?
