### PR TITLE
Update scopes used in OAuth

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -22,9 +22,9 @@ Additionally, this guide uses the following values that should be replaced in yo
 // The actual value used instead should be a URL that will be interpreted by your application.
 redirectUris = "urn:ietf:wg:oauth:2.0:oob"
 
-// This is equal to the full range of scopes currently supported by BigBone.
+// This is equal to the full range of non-admin scopes currently supported by BigBone.
 // Instead of this, you should request as little as possible for your application.
-scope = Scope()
+fullScope = Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL)
 ```
 
 ## Registering an App
@@ -46,7 +46,7 @@ val client: MastodonClient = MastodonClient.Builder(instanceHostname).build()
 val appRegistration = client.apps.createApp(
 	clientName = "bigbone-sample-app",
 	redirectUris = "urn:ietf:wg:oauth:2.0:oob",
-	scope = Scope(),
+	scope = fullScope,
 	website = "https://example.org/"
 ).execute()
 ```
@@ -64,7 +64,7 @@ try {
     AppRegistration appRegistration=client.apps().createApp(
         "bigbone-sample-app",
         "urn:ietf:wg:oauth:2.0:oob",
-        new Scope(),
+        fullScope,
         "https://example.org/"
     ).execute();
 } catch (BigBoneRequestException e) {

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxAppMethods.kt
@@ -20,7 +20,7 @@ class RxAppMethods(client: MastodonClient) {
      * @param clientName A name for your application
      * @param redirectUris Where the user should be redirected after authorization.
      * @param website A URL to the homepage of your app, defaults to null.
-     * @param scope Space separated list of scopes. Defaults to all scopes.
+     * @param scope Space separated list of scopes. Defaults to null, which is interpreted as requesting full "read" scope.
      * @see <a href="https://docs.joinmastodon.org/methods/apps/#create">Mastodon apps API methods #create</a>
      */
     @JvmOverloads
@@ -28,7 +28,7 @@ class RxAppMethods(client: MastodonClient) {
         clientName: String,
         redirectUris: String,
         website: String? = null,
-        scope: Scope = Scope(Scope.Name.ALL)
+        scope: Scope? = null
     ): Single<Application> = Single.fromCallable {
         appMethods.createApp(clientName, redirectUris, website, scope).execute()
     }

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxOAuthMethods.kt
@@ -51,19 +51,24 @@ class RxOAuthMethods(client: MastodonClient) {
      * @param clientSecret The client secret, obtained during app registration.
      * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @param code A user authorization code, obtained via the URL received from getOAuthUrl()
+     * @param scope Requested OAuth scopes. Must be equal to the scope requested from the user while obtaining [code].
+     *  If not provided, defaults to read.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
+    @JvmOverloads
     fun getUserAccessTokenWithAuthorizationCodeGrant(
         clientId: String,
         clientSecret: String,
         redirectUri: String,
-        code: String
+        code: String,
+        scope: Scope? = null
     ): Single<Token> = Single.fromCallable {
         oAuthMethods.getUserAccessTokenWithAuthorizationCodeGrant(
             clientId,
             clientSecret,
             redirectUri,
-            code
+            code,
+            scope
         ).execute()
     }
 
@@ -100,7 +105,8 @@ class RxOAuthMethods(client: MastodonClient) {
      * @param redirectUri Set a URI to redirect the user to.
      * @param username The Mastodon account username.
      * @param password The Mastodon account password.
-     * @param scope Requested OAuth scopes
+     * @param scope Requested OAuth scopes. Must be a subset of scopes declared during app registration.
+     *  If not provided, defaults to read.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
     @JvmOverloads
@@ -110,7 +116,7 @@ class RxOAuthMethods(client: MastodonClient) {
         redirectUri: String,
         username: String,
         password: String,
-        scope: Scope = Scope(Scope.Name.READ)
+        scope: Scope? = null
     ): Single<Token> = Single.fromCallable {
         oAuthMethods.getUserAccessTokenWithPasswordGrant(
             clientId,

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/TestConstants.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/TestConstants.kt
@@ -18,9 +18,6 @@ class TestConstants {
         const val USER2_EMAIL = "user2@email.dev"
         const val USER2_PASSWORD = "user2abcdef"
 
-        /**
-         * This scope should allow accessing all non-admin endpoints in integration tests.
-         */
-        val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+        val fullScope = Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL)
     }
 }

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/TestConstants.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/TestConstants.kt
@@ -1,5 +1,7 @@
 package social.bigbone
 
+import social.bigbone.api.Scope
+
 class TestConstants {
     companion object {
         const val REST_API_HOSTNAME = "localhost"
@@ -15,5 +17,10 @@ class TestConstants {
         const val USER2_USERNAME = "user2"
         const val USER2_EMAIL = "user2@email.dev"
         const val USER2_PASSWORD = "user2abcdef"
+
+        /**
+         * This scope should allow accessing all non-admin endpoints in integration tests.
+         */
+        val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
     }
 }

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/TestHelpers.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/TestHelpers.kt
@@ -7,6 +7,8 @@ import social.bigbone.api.entity.Token
 import java.io.File
 
 object TestHelpers {
+    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+
     fun uploadMediaFromResourcesFolder(filename: String, mediaType: String, client: MastodonClient): MediaAttachment {
         val classLoader = Thread.currentThread().contextClassLoader
         val uploadFile = File(classLoader.getResource(filename)!!.file)
@@ -26,7 +28,7 @@ object TestHelpers {
 
     fun createApp(appName: String): Application {
         val client = getTrustAllClient()
-        return client.apps.createApp(appName, TestConstants.REDIRECT_URI, null, Scope(Scope.Name.ALL)).execute()
+        return client.apps.createApp(appName, TestConstants.REDIRECT_URI, null, fullScope).execute()
     }
 
     fun getAppToken(application: Application): Token {
@@ -35,7 +37,7 @@ object TestHelpers {
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.ALL)
+            scope = fullScope
         ).execute()
     }
 
@@ -44,7 +46,7 @@ object TestHelpers {
         return client.oauth.getUserAccessTokenWithPasswordGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
-            scope = Scope(Scope.Name.ALL),
+            scope = fullScope,
             redirectUri = TestConstants.REDIRECT_URI,
             username = username,
             password = password

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/TestHelpers.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/TestHelpers.kt
@@ -1,14 +1,11 @@
 package social.bigbone
 
-import social.bigbone.api.Scope
 import social.bigbone.api.entity.Application
 import social.bigbone.api.entity.MediaAttachment
 import social.bigbone.api.entity.Token
 import java.io.File
 
 object TestHelpers {
-    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
-
     fun uploadMediaFromResourcesFolder(filename: String, mediaType: String, client: MastodonClient): MediaAttachment {
         val classLoader = Thread.currentThread().contextClassLoader
         val uploadFile = File(classLoader.getResource(filename)!!.file)
@@ -28,7 +25,7 @@ object TestHelpers {
 
     fun createApp(appName: String): Application {
         val client = getTrustAllClient()
-        return client.apps.createApp(appName, TestConstants.REDIRECT_URI, null, fullScope).execute()
+        return client.apps.createApp(appName, TestConstants.REDIRECT_URI, null, TestConstants.fullScope).execute()
     }
 
     fun getAppToken(application: Application): Token {
@@ -37,7 +34,7 @@ object TestHelpers {
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = fullScope
+            scope = TestConstants.fullScope
         ).execute()
     }
 
@@ -46,7 +43,7 @@ object TestHelpers {
         return client.oauth.getUserAccessTokenWithPasswordGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
-            scope = fullScope,
+            scope = TestConstants.fullScope,
             redirectUri = TestConstants.REDIRECT_URI,
             username = username,
             password = password

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/v300/V300StatusMethodsIntegrationTest.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/v300/V300StatusMethodsIntegrationTest.kt
@@ -15,6 +15,7 @@ import social.bigbone.api.entity.Token
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class V300StatusMethodsIntegrationTest {
+    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
     private lateinit var appToken: Token
     private lateinit var user2Token: Token
 
@@ -40,7 +41,7 @@ class V300StatusMethodsIntegrationTest {
         val client = MastodonClient.Builder(TestConstants.REST_API_HOSTNAME)
             .withTrustAllCerts()
             .build()
-        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, Scope(Scope.Name.ALL)).execute()
+        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, fullScope).execute()
     }
 
     private fun getAppToken(application: Application): Token {
@@ -51,7 +52,7 @@ class V300StatusMethodsIntegrationTest {
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.ALL)
+            scope = fullScope
         ).execute()
     }
 
@@ -62,7 +63,7 @@ class V300StatusMethodsIntegrationTest {
         return client.oauth.getUserAccessTokenWithPasswordGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
-            scope = Scope(Scope.Name.ALL),
+            scope = fullScope,
             redirectUri = TestConstants.REDIRECT_URI,
             username = username,
             password = password

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/v300/V300StatusMethodsIntegrationTest.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/v300/V300StatusMethodsIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import social.bigbone.MastodonClient
 import social.bigbone.TestConstants
-import social.bigbone.api.Scope
 import social.bigbone.api.entity.Application
 import social.bigbone.api.entity.Token
 
@@ -15,7 +14,6 @@ import social.bigbone.api.entity.Token
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class V300StatusMethodsIntegrationTest {
-    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
     private lateinit var appToken: Token
     private lateinit var user2Token: Token
 
@@ -41,7 +39,7 @@ class V300StatusMethodsIntegrationTest {
         val client = MastodonClient.Builder(TestConstants.REST_API_HOSTNAME)
             .withTrustAllCerts()
             .build()
-        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, fullScope).execute()
+        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, TestConstants.fullScope).execute()
     }
 
     private fun getAppToken(application: Application): Token {
@@ -52,7 +50,7 @@ class V300StatusMethodsIntegrationTest {
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = fullScope
+            scope = TestConstants.fullScope
         ).execute()
     }
 
@@ -63,7 +61,7 @@ class V300StatusMethodsIntegrationTest {
         return client.oauth.getUserAccessTokenWithPasswordGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
-            scope = fullScope,
+            scope = TestConstants.fullScope,
             redirectUri = TestConstants.REDIRECT_URI,
             username = username,
             password = password

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/v402/V402StatusMethodsIntegrationTest.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/v402/V402StatusMethodsIntegrationTest.kt
@@ -15,6 +15,7 @@ import social.bigbone.api.entity.Token
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class V402StatusMethodsIntegrationTest {
+    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
     private lateinit var appToken: Token
     private lateinit var user2Token: Token
 
@@ -40,7 +41,7 @@ class V402StatusMethodsIntegrationTest {
         val client = MastodonClient.Builder(TestConstants.REST_API_HOSTNAME)
             .withTrustAllCerts()
             .build()
-        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, Scope(Scope.Name.ALL)).execute()
+        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, fullScope).execute()
     }
 
     private fun getAppToken(application: Application): Token {
@@ -51,7 +52,7 @@ class V402StatusMethodsIntegrationTest {
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.ALL)
+            scope = fullScope
         ).execute()
     }
 
@@ -62,7 +63,7 @@ class V402StatusMethodsIntegrationTest {
         return client.oauth.getUserAccessTokenWithPasswordGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
-            scope = Scope(Scope.Name.ALL),
+            scope = fullScope,
             redirectUri = TestConstants.REDIRECT_URI,
             username = username,
             password = password

--- a/bigbone/src/integrationTest/kotlin/social/bigbone/v402/V402StatusMethodsIntegrationTest.kt
+++ b/bigbone/src/integrationTest/kotlin/social/bigbone/v402/V402StatusMethodsIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import social.bigbone.MastodonClient
 import social.bigbone.TestConstants
-import social.bigbone.api.Scope
 import social.bigbone.api.entity.Application
 import social.bigbone.api.entity.Token
 
@@ -15,7 +14,6 @@ import social.bigbone.api.entity.Token
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class V402StatusMethodsIntegrationTest {
-    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
     private lateinit var appToken: Token
     private lateinit var user2Token: Token
 
@@ -41,7 +39,7 @@ class V402StatusMethodsIntegrationTest {
         val client = MastodonClient.Builder(TestConstants.REST_API_HOSTNAME)
             .withTrustAllCerts()
             .build()
-        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, fullScope).execute()
+        return client.apps.createApp(TestConstants.USER2_APP_NAME, TestConstants.REDIRECT_URI, null, TestConstants.fullScope).execute()
     }
 
     private fun getAppToken(application: Application): Token {
@@ -52,7 +50,7 @@ class V402StatusMethodsIntegrationTest {
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = fullScope
+            scope = TestConstants.fullScope
         ).execute()
     }
 
@@ -63,7 +61,7 @@ class V402StatusMethodsIntegrationTest {
         return client.oauth.getUserAccessTokenWithPasswordGrant(
             clientId = application.clientId!!,
             clientSecret = application.clientSecret!!,
-            scope = fullScope,
+            scope = TestConstants.fullScope,
             redirectUri = TestConstants.REDIRECT_URI,
             username = username,
             password = password

--- a/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
@@ -3,16 +3,251 @@ package social.bigbone.api
 /**
  * Represents the access permissions that can be requested when registering an app or when
  * requesting access tokens.
+ * @param scopes individual scopes that should be requested.
  */
-class Scope @JvmOverloads constructor(private vararg val scopes: Name = arrayOf(Name.ALL)) {
+class Scope(private vararg val scopes: Name) {
 
     /**
-     * The available scopes.
+     * The available scopes. These scopes are hierarchical, i.e. if you have access to [READ], you automatically have
+     * access to [READ_ACCOUNTS]. It is recommended that you request as little as possible for your application.
      */
     enum class Name(val scopeName: String) {
+        /**
+         * Grants access to read data. Requesting this scope will also grant its child scopes.
+         */
         READ("read"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_ACCOUNTS("read:accounts"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_BLOCKS("read:blocks"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_BOOKMARKS("read:bookmarks"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_FAVOURITES("read:favourites"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_FILTERS("read:filters"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_FOLLOWS("read:follows"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_LISTS("read:lists"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_MUTES("read:mutes"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_NOTIFICATIONS("read:notifications"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_SEARCH("read:search"),
+
+        /**
+         * Child scope of [READ].
+         */
+        READ_STATUSES("read:statuses"),
+
+        /**
+         * Grants access to write data. Requesting this scope will also grant its child scopes
+         */
         WRITE("write"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_ACCOUNTS("write:accounts"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_BLOCKS("write:blocks"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_BOOKMARKS("write:bookmarks"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_CONVERSATIONS("write:conversations"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_FAVOURITES("write:favourites"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_FILTERS("write:filters"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_FOLLOWS("write:follows"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_LISTS("write:lists"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_MEDIA("write:media"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_MUTES("write:mutes"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_NOTIFICATIONS("write:notifications"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_REPORTS("write:reports"),
+
+        /**
+         * Child scope of [WRITE].
+         */
+        WRITE_STATUSES("write:statuses"),
+
+        /**
+         * Grants access to Web Push API subscriptions.
+         */
+        PUSH("push"),
+
+        /**
+         * Used for moderation API. Requesting this scope will also grant its child scopes.
+         */
+        ADMIN_READ("admin:read"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_ACCOUNTS("admin:read:accounts"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_REPORTS("admin:read:reports"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_DOMAIN_ALLOWS("admin:read:domain_allows"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_DOMAIN_BLOCKS("admin:read:domain_blocks"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_IP_BLOCKS("admin:read:ip_blocks"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_EMAIL_DOMAIN_BLOCKS("admin:read:email_domain_blocks"),
+
+        /**
+         * Child scope of [ADMIN_READ].
+         */
+        ADMIN_READ_CANONICAL_EMAIL_BLOCKS("admin:read:canonical_email_blocks"),
+
+        /**
+         * Used for moderation API. Requesting this scope will also grant its child scopes.
+         */
+        ADMIN_WRITE("admin:write"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_ACCOUNTS("admin:write:accounts"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_REPORTS("admin:write:reports"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_DOMAIN_ALLOWS("admin:write:domain_allows"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_DOMAIN_BLOCKS("admin:write:domain_blocks"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_IP_BLOCKS("admin:write:ip_blocks"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_EMAIL_DOMAIN_BLOCKS("admin:write:email_domain_blocks"),
+
+        /**
+         * Child scope of [ADMIN_WRITE].
+         */
+        ADMIN_WRITE_CANONICAL_EMAIL_BLOCKS("admin:write:canonical_email_blocks"),
+
+        /**
+         * Grants access to manage relationships. Requesting this scope will also grant the child scopes
+         * [READ_BLOCKS], [WRITE_BLOCKS], [READ_FOLLOWS], [WRITE_FOLLOWS], [READ_MUTES] and [WRITE_MUTES].
+         */
+        @Deprecated(
+            message = "Deprecated since Mastodon 3.5.0 and will be removed in the future. Use child scopes of READ and WRITE instead.",
+            level = DeprecationLevel.WARNING
+        )
         FOLLOW("follow"),
+
+        /**
+         * Grants full non-admin access by requesting the top-level scopes [READ], [WRITE] and [FOLLOW].
+         * It is recommended that you request as little as possible for your application, so consider using individual
+         * scopes instead.
+         */
+        @Deprecated(
+            message = "Includes FOLLOW scope deprecated since Mastodon 3.5.0, and will be removed in the future. " +
+                "If necessary, switch to requesting all top-level scopes directly.",
+            replaceWith = ReplaceWith("Scope(PUSH, READ, WRITE)"),
+            level = DeprecationLevel.WARNING
+        )
         ALL(Scope(READ, WRITE, FOLLOW).toString())
     }
 
@@ -20,5 +255,5 @@ class Scope @JvmOverloads constructor(private vararg val scopes: Name = arrayOf(
         require(scopes.size == scopes.distinct().size) { "There is a duplicate scope. : $this" }
     }
 
-    override fun toString(): String = scopes.joinToString(separator = " ", transform = { it.scopeName })
+    override fun toString(): String = scopes.distinct().joinToString(separator = " ", transform = { it.scopeName })
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
@@ -1,259 +1,438 @@
 package social.bigbone.api
 
 /**
- * Represents the access permissions that can be requested when registering an app or when
- * requesting access tokens.
+ * Represents the access permissions that can be requested when registering an app or when requesting access tokens.
+ * Existing scopes are available via members of this class, arranged hierarchically. It is recommended that you request
+ * as little as possible for your application.
  * @param scopes individual scopes that should be requested.
+ * @see <a href="https://docs.joinmastodon.org/api/oauth-scopes/">Mastodon OAuth scopes</a>
  */
+@Suppress("UseDataClass") // data class can not be used with primary constructor vararg parameters
 class Scope(private vararg val scopes: Name) {
 
     /**
-     * The available scopes. These scopes are hierarchical, i.e. if you have access to [READ], you automatically have
-     * access to [READ_ACCOUNTS]. It is recommended that you request as little as possible for your application.
+     * Interface to define scopes. While existing Mastodon scopes are generally available as objects of the [Scope]
+     * class, potential new scopes defined by Mastodon but not yet implemented here can be added by using this interface.
      */
-    enum class Name(val scopeName: String) {
+    interface Name {
+        val name: String
+    }
+
+    /**
+     * Scopes granting access to read data are grouped here. Use [READ.ALL] to request full read access, or preferably
+     * individual child scopes to limit access to a minimum.
+     */
+    object READ {
+
         /**
-         * Grants access to read data. Requesting this scope will also grant its child scopes.
+         * Grants access to read all data. Requesting this scope is equivalent to requesting all other [READ] child scopes.
          */
-        READ("read"),
+        @JvmField
+        val ALL = object : Name {
+            override val name: String
+                get() = "read"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_ACCOUNTS("read:accounts"),
+        @JvmField
+        val ACCOUNTS = object : Name {
+            override val name: String get() = "read:accounts"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_BLOCKS("read:blocks"),
+        @JvmField
+        val BLOCKS = object : Name {
+            override val name: String get() = "read:blocks"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_BOOKMARKS("read:bookmarks"),
+        @JvmField
+        val BOOKMARKS = object : Name {
+            override val name: String get() = "read:bookmarks"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_FAVOURITES("read:favourites"),
+        @JvmField
+        val FAVOURITES = object : Name {
+            override val name: String get() = "read:favourites"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_FILTERS("read:filters"),
+        @JvmField
+        val FILTERS = object : Name {
+            override val name: String get() = "read:filters"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_FOLLOWS("read:follows"),
+        @JvmField
+        val FOLLOWS = object : Name {
+            override val name: String get() = "read:follows"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_LISTS("read:lists"),
+        @JvmField
+        val LISTS = object : Name {
+            override val name: String get() = "read:lists"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_MUTES("read:mutes"),
+        @JvmField
+        val MUTES = object : Name {
+            override val name: String get() = "read:mutes"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_NOTIFICATIONS("read:notifications"),
+        @JvmField
+        val NOTIFICATIONS = object : Name {
+            override val name: String get() = "read:notifications"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_SEARCH("read:search"),
+        @JvmField
+        val SEARCH = object : Name {
+            override val name: String get() = "read:search"
+        }
 
         /**
          * Child scope of [READ].
          */
-        READ_STATUSES("read:statuses"),
+        @JvmField
+        val STATUSES = object : Name {
+            override val name: String get() = "read:statuses"
+        }
+    }
+
+    /**
+     * Scopes granting access to write data are grouped here. Use [WRITE.ALL] to request full write access, or preferably
+     * individual child scopes to limit access to a minimum.
+     */
+    object WRITE {
 
         /**
-         * Grants access to write data. Requesting this scope will also grant its child scopes
+         * Grants access to write all data. Requesting this scope is equivalent to requesting all other child scopes.
          */
-        WRITE("write"),
-
-        /**
-         * Child scope of [WRITE].
-         */
-        WRITE_ACCOUNTS("write:accounts"),
-
-        /**
-         * Child scope of [WRITE].
-         */
-        WRITE_BLOCKS("write:blocks"),
-
-        /**
-         * Child scope of [WRITE].
-         */
-        WRITE_BOOKMARKS("write:bookmarks"),
-
-        /**
-         * Child scope of [WRITE].
-         */
-        WRITE_CONVERSATIONS("write:conversations"),
+        @JvmField
+        val ALL = object : Name {
+            override val name: String
+                get() = "write"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_FAVOURITES("write:favourites"),
+        @JvmField
+        val ACCOUNTS = object : Name {
+            override val name: String get() = "write:accounts"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_FILTERS("write:filters"),
+        @JvmField
+        val BLOCKS = object : Name {
+            override val name: String get() = "write:blocks"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_FOLLOWS("write:follows"),
+        @JvmField
+        val BOOKMARKS = object : Name {
+            override val name: String get() = "write:bookmarks"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_LISTS("write:lists"),
+        @JvmField
+        val CONVERSATIONS = object : Name {
+            override val name: String get() = "write:conversations"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_MEDIA("write:media"),
+        @JvmField
+        val FAVOURITES = object : Name {
+            override val name: String get() = "write:favourites"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_MUTES("write:mutes"),
+        @JvmField
+        val FILTERS = object : Name {
+            override val name: String get() = "write:filters"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_NOTIFICATIONS("write:notifications"),
+        @JvmField
+        val FOLLOWS = object : Name {
+            override val name: String get() = "write:follows"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_REPORTS("write:reports"),
+        @JvmField
+        val LISTS = object : Name {
+            override val name: String get() = "write:lists"
+        }
 
         /**
          * Child scope of [WRITE].
          */
-        WRITE_STATUSES("write:statuses"),
+        @JvmField
+        val MEDIA = object : Name {
+            override val name: String get() = "write:media"
+        }
+
+        /**
+         * Child scope of [WRITE].
+         */
+        @JvmField
+        val MUTES = object : Name {
+            override val name: String get() = "write:mutes"
+        }
+
+        /**
+         * Child scope of [WRITE].
+         */
+        @JvmField
+        val NOTIFICATIONS = object : Name {
+            override val name: String get() = "write:notifications"
+        }
+
+        /**
+         * Child scope of [WRITE].
+         */
+        @JvmField
+        val REPORTS = object : Name {
+            override val name: String get() = "write:reports"
+        }
+
+        /**
+         * Child scope of [WRITE].
+         */
+        @JvmField
+        val STATUSES = object : Name {
+            override val name: String get() = "write:statuses"
+        }
+    }
+
+    /**
+     * Scopes granting access to Web Push API subscriptions are grouped here. Currently, only [PUSH.ALL] exists.
+     */
+    object PUSH {
 
         /**
          * Grants access to Web Push API subscriptions.
          */
-        PUSH("push"),
-
-        /**
-         * Used for moderation API. Requesting this scope will also grant its child scopes.
-         */
-        ADMIN_READ("admin:read"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_ACCOUNTS("admin:read:accounts"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_REPORTS("admin:read:reports"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_DOMAIN_ALLOWS("admin:read:domain_allows"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_DOMAIN_BLOCKS("admin:read:domain_blocks"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_IP_BLOCKS("admin:read:ip_blocks"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_EMAIL_DOMAIN_BLOCKS("admin:read:email_domain_blocks"),
-
-        /**
-         * Child scope of [ADMIN_READ].
-         */
-        ADMIN_READ_CANONICAL_EMAIL_BLOCKS("admin:read:canonical_email_blocks"),
-
-        /**
-         * Used for moderation API. Requesting this scope will also grant its child scopes.
-         */
-        ADMIN_WRITE("admin:write"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_ACCOUNTS("admin:write:accounts"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_REPORTS("admin:write:reports"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_DOMAIN_ALLOWS("admin:write:domain_allows"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_DOMAIN_BLOCKS("admin:write:domain_blocks"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_IP_BLOCKS("admin:write:ip_blocks"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_EMAIL_DOMAIN_BLOCKS("admin:write:email_domain_blocks"),
-
-        /**
-         * Child scope of [ADMIN_WRITE].
-         */
-        ADMIN_WRITE_CANONICAL_EMAIL_BLOCKS("admin:write:canonical_email_blocks"),
-
-        /**
-         * Grants access to manage relationships. Requesting this scope will also grant the child scopes
-         * [READ_BLOCKS], [WRITE_BLOCKS], [READ_FOLLOWS], [WRITE_FOLLOWS], [READ_MUTES] and [WRITE_MUTES].
-         */
-        @Deprecated(
-            message = "Deprecated since Mastodon 3.5.0 and will be removed in the future. Use child scopes of READ and WRITE instead.",
-            level = DeprecationLevel.WARNING
-        )
-        FOLLOW("follow"),
-
-        /**
-         * Grants full non-admin access by requesting the top-level scopes [READ], [WRITE] and [FOLLOW].
-         * It is recommended that you request as little as possible for your application, so consider using individual
-         * scopes instead.
-         */
-        @Deprecated(
-            message = "Includes FOLLOW scope deprecated since Mastodon 3.5.0, and will be removed in the future. " +
-                "If necessary, switch to requesting all top-level scopes directly.",
-            replaceWith = ReplaceWith("Scope(PUSH, READ, WRITE)"),
-            level = DeprecationLevel.WARNING
-        )
-        ALL(Scope(READ, WRITE, FOLLOW).toString())
+        @JvmField
+        val ALL = object : Name {
+            override val name: String get() = "push"
+        }
     }
 
-    fun validate() {
-        require(scopes.size == scopes.distinct().size) { "There is a duplicate scope. : $this" }
+    /**
+     * Scopes granting access to the moderation API are grouped here, split between [ADMIN.READ] and [ADMIN.WRITE] for
+     * read and write access, respectively.
+     */
+    object ADMIN {
+
+        /**
+         * Scopes granting read access to the moderation API are grouped here. Use [ADMIN.READ.ALL] to request full
+         * read access, or preferably individual child scopes to limit access to a minimum.
+         */
+        object READ {
+
+            /**
+             * Grants read access to the moderation API. Requesting this scope is equivalent to requesting all other
+             * child scopes.
+             */
+            @JvmField
+            val ALL = object : Name {
+                override val name: String get() = "admin:read"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val ACCOUNTS = object : Name {
+                override val name: String get() = "admin:read:accounts"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val REPORTS = object : Name {
+                override val name: String get() = "admin:read:reports"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val DOMAIN_ALLOWS = object : Name {
+                override val name: String get() = "admin:read:domain_allows"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val DOMAIN_BLOCKS = object : Name {
+                override val name: String get() = "admin:read:domain_blocks"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val IP_BLOCKS = object : Name {
+                override val name: String get() = "admin:read:ip_blocks"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val EMAIL_DOMAIN_BLOCKS = object : Name {
+                override val name: String get() = "admin:read:email_domain_blocks"
+            }
+
+            /**
+             * Child scope of [ADMIN.READ].
+             */
+            @JvmField
+            val CANONICAL_EMAIL_BLOCKS = object : Name {
+                override val name: String get() = "admin:read:canonical_email_blocks"
+            }
+        }
+
+        /**
+         * Scopes granting write access to the moderation API are grouped here. Use [ADMIN.WRITE.ALL] to request full
+         * write access, or preferably individual child scopes to limit access to a minimum.
+         */
+        object WRITE {
+
+            /**
+             * Grants write access to the moderation API. Requesting this scope is equivalent to requesting all other
+             * child scopes.
+             */
+            @JvmField
+            val ALL = object : Name {
+                override val name: String get() = "admin:write"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val ACCOUNTS = object : Name {
+                override val name: String get() = "admin:write:accounts"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val REPORTS = object : Name {
+                override val name: String get() = "admin:write:reports"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val DOMAIN_ALLOWS = object : Name {
+                override val name: String get() = "admin:write:domain_allows"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val DOMAIN_BLOCKS = object : Name {
+                override val name: String get() = "admin:write:domain_blocks"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val IP_BLOCKS = object : Name {
+                override val name: String get() = "admin:write:ip_blocks"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val EMAIL_DOMAIN_BLOCKS = object : Name {
+                override val name: String get() = "admin:write:email_domain_blocks"
+            }
+
+            /**
+             * Child scope of [ADMIN.WRITE].
+             */
+            @JvmField
+            val CANONICAL_EMAIL_BLOCKS = object : Name {
+                override val name: String get() = "admin:write:canonical_email_blocks"
+            }
+        }
     }
 
-    override fun toString(): String = scopes.distinct().joinToString(separator = " ", transform = { it.scopeName })
+    /**
+     * Grants access to manage relationships. Requesting this scope will also grant the child scopes
+     * [READ.BLOCKS], [WRITE.BLOCKS], [READ.FOLLOWS], [WRITE.FOLLOWS], [READ.MUTES] and [WRITE.MUTES].
+     */
+    @Deprecated(
+        message = "Deprecated since Mastodon 3.5.0 and will be removed in the future. Use child scopes of READ and WRITE instead.",
+        level = DeprecationLevel.WARNING
+    )
+    object FOLLOW : Name {
+        override val name: String get() = "follow"
+    }
+
+    /**
+     * Grants full non-admin access by requesting the top-level scopes [READ], [WRITE] and [FOLLOW].
+     * It is recommended that you request as little as possible for your application, so consider using individual
+     * scopes instead.
+     */
+    @Deprecated(
+        message = "Includes FOLLOW scope deprecated since Mastodon 3.5.0, and will be removed in the future. " +
+            "If necessary, switch to requesting all top-level scopes directly.",
+        replaceWith = ReplaceWith("Scope(READ, WRITE, PUSH)"),
+        level = DeprecationLevel.WARNING
+    )
+    object ALL : Name {
+        override val name: String get() = "read write follow"
+    }
+
+    override fun toString(): String = scopes.distinct().joinToString(separator = " ", transform = { it.name })
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
@@ -407,32 +407,5 @@ class Scope(private vararg val scopes: Name) {
         }
     }
 
-    /**
-     * Grants access to manage relationships. Requesting this scope will also grant the child scopes
-     * [READ.BLOCKS], [WRITE.BLOCKS], [READ.FOLLOWS], [WRITE.FOLLOWS], [READ.MUTES] and [WRITE.MUTES].
-     */
-    @Deprecated(
-        message = "Deprecated since Mastodon 3.5.0 and will be removed in the future. Use child scopes of READ and WRITE instead.",
-        level = DeprecationLevel.WARNING
-    )
-    object FOLLOW : Name {
-        override val name: String get() = "follow"
-    }
-
-    /**
-     * Grants full non-admin access by requesting the top-level scopes [READ], [WRITE] and [FOLLOW].
-     * It is recommended that you request as little as possible for your application, so consider using individual
-     * scopes instead.
-     */
-    @Deprecated(
-        message = "Includes FOLLOW scope deprecated since Mastodon 3.5.0, and will be removed in the future. " +
-            "If necessary, switch to requesting all top-level scopes directly.",
-        replaceWith = ReplaceWith("Scope(READ, WRITE, PUSH)"),
-        level = DeprecationLevel.WARNING
-    )
-    object ALL : Name {
-        override val name: String get() = "read write follow"
-    }
-
     override fun toString(): String = scopes.distinct().joinToString(separator = " ", transform = { it.name })
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
@@ -30,69 +30,36 @@ class Scope(private vararg val scopes: Name) {
         @JvmField
         val ALL = Name { "read" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val ACCOUNTS = Name { "read:accounts" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val BLOCKS = Name { "read:blocks" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val BOOKMARKS = Name { "read:bookmarks" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val FAVOURITES = Name { "read:favourites" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val FILTERS = Name { "read:filters" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val FOLLOWS = Name { "read:follows" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val LISTS = Name { "read:lists" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val MUTES = Name { "read:mutes" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val NOTIFICATIONS = Name { "read:notifications" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val SEARCH = Name { "read:search" }
 
-        /**
-         * Child scope of [READ].
-         */
         @JvmField
         val STATUSES = Name { "read:statuses" }
     }
@@ -109,81 +76,42 @@ class Scope(private vararg val scopes: Name) {
         @JvmField
         val ALL = Name { "write" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val ACCOUNTS = Name { "write:accounts" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val BLOCKS = Name { "write:blocks" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val BOOKMARKS = Name { "write:bookmarks" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val CONVERSATIONS = Name { "write:conversations" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val FAVOURITES = Name { "write:favourites" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val FILTERS = Name { "write:filters" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val FOLLOWS = Name { "write:follows" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val LISTS = Name { "write:lists" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val MEDIA = Name { "write:media" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val MUTES = Name { "write:mutes" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val NOTIFICATIONS = Name { "write:notifications" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val REPORTS = Name { "write:reports" }
 
-        /**
-         * Child scope of [WRITE].
-         */
         @JvmField
         val STATUSES = Name { "write:statuses" }
     }
@@ -219,45 +147,24 @@ class Scope(private vararg val scopes: Name) {
             @JvmField
             val ALL = Name { "admin:read" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val ACCOUNTS = Name { "admin:read:accounts" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val REPORTS = Name { "admin:read:reports" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val DOMAIN_ALLOWS = Name { "admin:read:domain_allows" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val DOMAIN_BLOCKS = Name { "admin:read:domain_blocks" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val IP_BLOCKS = Name { "admin:read:ip_blocks" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val EMAIL_DOMAIN_BLOCKS = Name { "admin:read:email_domain_blocks" }
 
-            /**
-             * Child scope of [ADMIN.READ].
-             */
             @JvmField
             val CANONICAL_EMAIL_BLOCKS = Name { "admin:read:canonical_email_blocks" }
         }
@@ -275,45 +182,24 @@ class Scope(private vararg val scopes: Name) {
             @JvmField
             val ALL = Name { "admin:write" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val ACCOUNTS = Name { "admin:write:accounts" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val REPORTS = Name { "admin:write:reports" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val DOMAIN_ALLOWS = Name { "admin:write:domain_allows" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val DOMAIN_BLOCKS = Name { "admin:write:domain_blocks" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val IP_BLOCKS = Name { "admin:write:ip_blocks" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val EMAIL_DOMAIN_BLOCKS = Name { "admin:write:email_domain_blocks" }
 
-            /**
-             * Child scope of [ADMIN.WRITE].
-             */
             @JvmField
             val CANONICAL_EMAIL_BLOCKS = Name { "admin:write:canonical_email_blocks" }
         }

--- a/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/Scope.kt
@@ -14,8 +14,8 @@ class Scope(private vararg val scopes: Name) {
      * Interface to define scopes. While existing Mastodon scopes are generally available as objects of the [Scope]
      * class, potential new scopes defined by Mastodon but not yet implemented here can be added by using this interface.
      */
-    interface Name {
-        val name: String
+    fun interface Name {
+        fun name(): String
     }
 
     /**
@@ -28,98 +28,73 @@ class Scope(private vararg val scopes: Name) {
          * Grants access to read all data. Requesting this scope is equivalent to requesting all other [READ] child scopes.
          */
         @JvmField
-        val ALL = object : Name {
-            override val name: String
-                get() = "read"
-        }
+        val ALL = Name { "read" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val ACCOUNTS = object : Name {
-            override val name: String get() = "read:accounts"
-        }
+        val ACCOUNTS = Name { "read:accounts" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val BLOCKS = object : Name {
-            override val name: String get() = "read:blocks"
-        }
+        val BLOCKS = Name { "read:blocks" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val BOOKMARKS = object : Name {
-            override val name: String get() = "read:bookmarks"
-        }
+        val BOOKMARKS = Name { "read:bookmarks" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val FAVOURITES = object : Name {
-            override val name: String get() = "read:favourites"
-        }
+        val FAVOURITES = Name { "read:favourites" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val FILTERS = object : Name {
-            override val name: String get() = "read:filters"
-        }
+        val FILTERS = Name { "read:filters" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val FOLLOWS = object : Name {
-            override val name: String get() = "read:follows"
-        }
+        val FOLLOWS = Name { "read:follows" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val LISTS = object : Name {
-            override val name: String get() = "read:lists"
-        }
+        val LISTS = Name { "read:lists" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val MUTES = object : Name {
-            override val name: String get() = "read:mutes"
-        }
+        val MUTES = Name { "read:mutes" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val NOTIFICATIONS = object : Name {
-            override val name: String get() = "read:notifications"
-        }
+        val NOTIFICATIONS = Name { "read:notifications" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val SEARCH = object : Name {
-            override val name: String get() = "read:search"
-        }
+        val SEARCH = Name { "read:search" }
 
         /**
          * Child scope of [READ].
          */
         @JvmField
-        val STATUSES = object : Name {
-            override val name: String get() = "read:statuses"
-        }
+        val STATUSES = Name { "read:statuses" }
     }
 
     /**
@@ -132,114 +107,85 @@ class Scope(private vararg val scopes: Name) {
          * Grants access to write all data. Requesting this scope is equivalent to requesting all other child scopes.
          */
         @JvmField
-        val ALL = object : Name {
-            override val name: String
-                get() = "write"
-        }
+        val ALL = Name { "write" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val ACCOUNTS = object : Name {
-            override val name: String get() = "write:accounts"
-        }
+        val ACCOUNTS = Name { "write:accounts" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val BLOCKS = object : Name {
-            override val name: String get() = "write:blocks"
-        }
+        val BLOCKS = Name { "write:blocks" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val BOOKMARKS = object : Name {
-            override val name: String get() = "write:bookmarks"
-        }
+        val BOOKMARKS = Name { "write:bookmarks" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val CONVERSATIONS = object : Name {
-            override val name: String get() = "write:conversations"
-        }
+        val CONVERSATIONS = Name { "write:conversations" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val FAVOURITES = object : Name {
-            override val name: String get() = "write:favourites"
-        }
+        val FAVOURITES = Name { "write:favourites" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val FILTERS = object : Name {
-            override val name: String get() = "write:filters"
-        }
+        val FILTERS = Name { "write:filters" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val FOLLOWS = object : Name {
-            override val name: String get() = "write:follows"
-        }
+        val FOLLOWS = Name { "write:follows" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val LISTS = object : Name {
-            override val name: String get() = "write:lists"
-        }
+        val LISTS = Name { "write:lists" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val MEDIA = object : Name {
-            override val name: String get() = "write:media"
-        }
+        val MEDIA = Name { "write:media" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val MUTES = object : Name {
-            override val name: String get() = "write:mutes"
-        }
+        val MUTES = Name { "write:mutes" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val NOTIFICATIONS = object : Name {
-            override val name: String get() = "write:notifications"
-        }
+        val NOTIFICATIONS = Name { "write:notifications" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val REPORTS = object : Name {
-            override val name: String get() = "write:reports"
-        }
+        val REPORTS = Name { "write:reports" }
 
         /**
          * Child scope of [WRITE].
          */
         @JvmField
-        val STATUSES = object : Name {
-            override val name: String get() = "write:statuses"
-        }
+        val STATUSES = Name { "write:statuses" }
     }
 
     /**
@@ -251,9 +197,7 @@ class Scope(private vararg val scopes: Name) {
          * Grants access to Web Push API subscriptions.
          */
         @JvmField
-        val ALL = object : Name {
-            override val name: String get() = "push"
-        }
+        val ALL = Name { "push" }
     }
 
     /**
@@ -273,65 +217,49 @@ class Scope(private vararg val scopes: Name) {
              * child scopes.
              */
             @JvmField
-            val ALL = object : Name {
-                override val name: String get() = "admin:read"
-            }
+            val ALL = Name { "admin:read" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val ACCOUNTS = object : Name {
-                override val name: String get() = "admin:read:accounts"
-            }
+            val ACCOUNTS = Name { "admin:read:accounts" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val REPORTS = object : Name {
-                override val name: String get() = "admin:read:reports"
-            }
+            val REPORTS = Name { "admin:read:reports" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val DOMAIN_ALLOWS = object : Name {
-                override val name: String get() = "admin:read:domain_allows"
-            }
+            val DOMAIN_ALLOWS = Name { "admin:read:domain_allows" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val DOMAIN_BLOCKS = object : Name {
-                override val name: String get() = "admin:read:domain_blocks"
-            }
+            val DOMAIN_BLOCKS = Name { "admin:read:domain_blocks" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val IP_BLOCKS = object : Name {
-                override val name: String get() = "admin:read:ip_blocks"
-            }
+            val IP_BLOCKS = Name { "admin:read:ip_blocks" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val EMAIL_DOMAIN_BLOCKS = object : Name {
-                override val name: String get() = "admin:read:email_domain_blocks"
-            }
+            val EMAIL_DOMAIN_BLOCKS = Name { "admin:read:email_domain_blocks" }
 
             /**
              * Child scope of [ADMIN.READ].
              */
             @JvmField
-            val CANONICAL_EMAIL_BLOCKS = object : Name {
-                override val name: String get() = "admin:read:canonical_email_blocks"
-            }
+            val CANONICAL_EMAIL_BLOCKS = Name { "admin:read:canonical_email_blocks" }
         }
 
         /**
@@ -345,67 +273,51 @@ class Scope(private vararg val scopes: Name) {
              * child scopes.
              */
             @JvmField
-            val ALL = object : Name {
-                override val name: String get() = "admin:write"
-            }
+            val ALL = Name { "admin:write" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val ACCOUNTS = object : Name {
-                override val name: String get() = "admin:write:accounts"
-            }
+            val ACCOUNTS = Name { "admin:write:accounts" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val REPORTS = object : Name {
-                override val name: String get() = "admin:write:reports"
-            }
+            val REPORTS = Name { "admin:write:reports" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val DOMAIN_ALLOWS = object : Name {
-                override val name: String get() = "admin:write:domain_allows"
-            }
+            val DOMAIN_ALLOWS = Name { "admin:write:domain_allows" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val DOMAIN_BLOCKS = object : Name {
-                override val name: String get() = "admin:write:domain_blocks"
-            }
+            val DOMAIN_BLOCKS = Name { "admin:write:domain_blocks" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val IP_BLOCKS = object : Name {
-                override val name: String get() = "admin:write:ip_blocks"
-            }
+            val IP_BLOCKS = Name { "admin:write:ip_blocks" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val EMAIL_DOMAIN_BLOCKS = object : Name {
-                override val name: String get() = "admin:write:email_domain_blocks"
-            }
+            val EMAIL_DOMAIN_BLOCKS = Name { "admin:write:email_domain_blocks" }
 
             /**
              * Child scope of [ADMIN.WRITE].
              */
             @JvmField
-            val CANONICAL_EMAIL_BLOCKS = object : Name {
-                override val name: String get() = "admin:write:canonical_email_blocks"
-            }
+            val CANONICAL_EMAIL_BLOCKS = Name { "admin:write:canonical_email_blocks" }
         }
     }
 
-    override fun toString(): String = scopes.distinct().joinToString(separator = " ", transform = { it.name })
+    override fun toString(): String = scopes.distinct().joinToString(separator = " ", transform = { it.name() })
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
@@ -16,7 +16,7 @@ class AppMethods(private val client: MastodonClient) {
      * @param clientName A name for your application
      * @param redirectUris Where the user should be redirected after authorization.
      * @param website A URL to the homepage of your app, defaults to null.
-     * @param scope Space separated list of scopes. Defaults to all scopes.
+     * @param scope Space separated list of scopes. Defaults to null, which is interpreted as requesting full "read" scope.
      * @see <a href="https://docs.joinmastodon.org/methods/apps/#create">Mastodon apps API methods #create</a>
      */
     @JvmOverloads
@@ -24,18 +24,19 @@ class AppMethods(private val client: MastodonClient) {
         clientName: String,
         redirectUris: String,
         website: String? = null,
-        scope: Scope = Scope(Scope.Name.ALL)
+        scope: Scope? = null
     ): MastodonRequest<Application> {
-        scope.validate()
         return client.getMastodonRequest(
             endpoint = "api/v1/apps",
             method = MastodonClient.Method.POST,
             parameters = Parameters().apply {
                 append("client_name", clientName)
-                append("scopes", scope.toString())
                 append("redirect_uris", redirectUris)
                 website?.let {
                     append("website", it)
+                }
+                scope?.let {
+                    append("scopes", scope.toString())
                 }
             }
         )

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/AppMethods.kt
@@ -36,6 +36,8 @@ class AppMethods(private val client: MastodonClient) {
                     append("website", it)
                 }
                 scope?.let {
+                    // note: Mastodon uses "scopes" in its own API, but "scope" in OAuth APIs
+                    //  see https://docs.joinmastodon.org/api/oauth-scopes/#oauth-scopes
                     append("scopes", scope.toString())
                 }
             }

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/OAuthMethods.kt
@@ -59,13 +59,17 @@ class OAuthMethods(private val client: MastodonClient) {
      * @param clientSecret The client secret, obtained during app registration.
      * @param redirectUri Set a URI to redirect the user to. Must match one of the redirect_uris declared during app registration.
      * @param code A user authorization code, obtained via the URL received from getOAuthUrl()
+     * @param scope Requested OAuth scopes. Must be equal to the scope requested from the user while obtaining [code].
+     *  If not provided, defaults to read.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
+    @JvmOverloads
     fun getUserAccessTokenWithAuthorizationCodeGrant(
         clientId: String,
         clientSecret: String,
         redirectUri: String,
-        code: String
+        code: String,
+        scope: Scope? = null
     ): MastodonRequest<Token> {
         return client.getMastodonRequest(
             endpoint = "oauth/token",
@@ -76,6 +80,7 @@ class OAuthMethods(private val client: MastodonClient) {
                 append("redirect_uri", redirectUri)
                 append("code", code)
                 append("grant_type", GrantTypes.AUTHORIZATION_CODE.value)
+                scope?.let { append("scope", scope.toString()) }
             }
         )
     }
@@ -120,7 +125,8 @@ class OAuthMethods(private val client: MastodonClient) {
      * @param redirectUri Set a URI to redirect the user to.
      * @param username The Mastodon account username.
      * @param password The Mastodon account password.
-     * @param scope Requested OAuth scopes
+     * @param scope Requested OAuth scopes. Must be a subset of scopes declared during app registration.
+     *  If not provided, defaults to read.
      * @see <a href="https://docs.joinmastodon.org/methods/oauth/#token">Mastodon oauth API methods #token</a>
      */
     @JvmOverloads
@@ -130,7 +136,7 @@ class OAuthMethods(private val client: MastodonClient) {
         redirectUri: String,
         username: String,
         password: String,
-        scope: Scope = Scope(Scope.Name.READ)
+        scope: Scope? = null
     ): MastodonRequest<Token> {
         return client.getMastodonRequest(
             endpoint = "oauth/token",
@@ -138,11 +144,11 @@ class OAuthMethods(private val client: MastodonClient) {
             parameters = Parameters().apply {
                 append("client_id", clientId)
                 append("client_secret", clientSecret)
-                append("scope", scope.toString())
                 append("redirect_uri", redirectUri)
                 append("username", username)
                 append("password", password)
                 append("grant_type", GrantTypes.PASSWORD.value)
+                scope?.let { append("scope", scope.toString()) }
             }
         )
     }

--- a/bigbone/src/test/assets/access_token.json
+++ b/bigbone/src/test/assets/access_token.json
@@ -1,6 +1,6 @@
 {
   "access_token": "test",
   "token_type": "bearer",
-  "scope": "read write follow",
+  "scope": "read write",
   "created_at": 1493188835
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/entity/TokenTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/entity/TokenTest.kt
@@ -13,7 +13,7 @@ class TokenTest {
         val accessToken: Token = JSON_SERIALIZER.decodeFromString(json)
         accessToken.accessToken shouldBeEqualTo "test"
         accessToken.tokenType shouldBeEqualTo "bearer"
-        accessToken.scope shouldBeEqualTo "read write follow"
+        accessToken.scope shouldBeEqualTo "read write"
         accessToken.createdAt shouldBeEqualTo 1_493_188_835L
     }
 

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.MastodonClient
 import social.bigbone.TestConstants
-import social.bigbone.api.Scope
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
 
@@ -19,8 +18,7 @@ class AppMethodsTest {
         val appMethods = AppMethods(client)
         val application = appMethods.createApp(
             clientName = "bigbone-sample-app",
-            redirectUris = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+            redirectUris = TestConstants.REDIRECT_URI
         ).execute()
 
         application.clientId shouldBeEqualTo "client id"
@@ -34,8 +32,7 @@ class AppMethodsTest {
             val appMethods = AppMethods(client)
             appMethods.createApp(
                 clientName = "bigbone-sample-app",
-                redirectUris = TestConstants.REDIRECT_URI,
-                scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+                redirectUris = TestConstants.REDIRECT_URI
             ).execute()
         }
     }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/AppMethodsTest.kt
@@ -20,7 +20,7 @@ class AppMethodsTest {
         val application = appMethods.createApp(
             clientName = "bigbone-sample-app",
             redirectUris = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.ALL)
+            scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
         ).execute()
 
         application.clientId shouldBeEqualTo "client id"
@@ -35,7 +35,7 @@ class AppMethodsTest {
             appMethods.createApp(
                 clientName = "bigbone-sample-app",
                 redirectUris = TestConstants.REDIRECT_URI,
-                scope = Scope(Scope.Name.ALL)
+                scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
             ).execute()
         }
     }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
@@ -27,11 +27,11 @@ class OAuthMethodsTest {
         val url = OAuthMethods(client).getOAuthUrl(
             clientId = "client_id",
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+            scope = Scope(Scope.Name.READ, Scope.Name.WRITE_ACCOUNTS, Scope.Name.ADMIN_READ_REPORTS)
         )
 
         url shouldBeEqualTo "https://mastodon.cloud/oauth/authorize?client_id=client_id" +
-            "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write+push"
+            "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write%3Aaccounts+admin%3Aread%3Areports"
     }
 
     @Test
@@ -64,7 +64,7 @@ class OAuthMethodsTest {
             code = "test"
         ).execute()
         accessToken.accessToken shouldBeEqualTo "test"
-        accessToken.scope shouldBeEqualTo "read write follow"
+        accessToken.scope shouldBeEqualTo "read write"
         accessToken.tokenType shouldBeEqualTo "bearer"
         accessToken.createdAt shouldBeEqualTo 1_493_188_835
     }
@@ -95,7 +95,7 @@ class OAuthMethodsTest {
             redirectUri = TestConstants.REDIRECT_URI
         ).execute()
         accessToken.accessToken shouldBeEqualTo "test"
-        accessToken.scope shouldBeEqualTo "read write follow"
+        accessToken.scope shouldBeEqualTo "read write"
         accessToken.tokenType shouldBeEqualTo "bearer"
         accessToken.createdAt shouldBeEqualTo 1_493_188_835
     }
@@ -124,11 +124,10 @@ class OAuthMethodsTest {
             "test",
             TestConstants.REDIRECT_URI,
             "test",
-            "test",
-            Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+            "test"
         ).execute()
         accessToken.accessToken shouldBeEqualTo "test"
-        accessToken.scope shouldBeEqualTo "read write follow"
+        accessToken.scope shouldBeEqualTo "read write"
         accessToken.tokenType shouldBeEqualTo "bearer"
         accessToken.createdAt shouldBeEqualTo 1_493_188_835
     }
@@ -142,7 +141,6 @@ class OAuthMethodsTest {
             oauth.getUserAccessTokenWithPasswordGrant(
                 clientId = "test",
                 clientSecret = "test",
-                scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH),
                 redirectUri = TestConstants.REDIRECT_URI,
                 username = "test",
                 password = "test"

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
@@ -27,7 +27,7 @@ class OAuthMethodsTest {
         val url = OAuthMethods(client).getOAuthUrl(
             clientId = "client_id",
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.READ, Scope.Name.WRITE_ACCOUNTS, Scope.Name.ADMIN_READ_REPORTS)
+            scope = Scope(Scope.READ.ALL, Scope.WRITE.ACCOUNTS, Scope.ADMIN.READ.REPORTS)
         )
 
         url shouldBeEqualTo "https://mastodon.cloud/oauth/authorize?client_id=client_id" +

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/OAuthMethodsTest.kt
@@ -27,11 +27,11 @@ class OAuthMethodsTest {
         val url = OAuthMethods(client).getOAuthUrl(
             clientId = "client_id",
             redirectUri = TestConstants.REDIRECT_URI,
-            scope = Scope(Scope.Name.ALL)
+            scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
         )
 
         url shouldBeEqualTo "https://mastodon.cloud/oauth/authorize?client_id=client_id" +
-            "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write+follow"
+            "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=read+write+push"
     }
 
     @Test
@@ -125,7 +125,7 @@ class OAuthMethodsTest {
             TestConstants.REDIRECT_URI,
             "test",
             "test",
-            Scope(Scope.Name.ALL)
+            Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
         ).execute()
         accessToken.accessToken shouldBeEqualTo "test"
         accessToken.scope shouldBeEqualTo "read write follow"
@@ -142,7 +142,7 @@ class OAuthMethodsTest {
             oauth.getUserAccessTokenWithPasswordGrant(
                 clientId = "test",
                 clientSecret = "test",
-                scope = Scope(Scope.Name.ALL),
+                scope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH),
                 redirectUri = TestConstants.REDIRECT_URI,
                 username = "test",
                 password = "test"

--- a/bigbone/src/test/kotlin/social/bigbone/entity/ScopeTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/entity/ScopeTest.kt
@@ -1,7 +1,6 @@
 package social.bigbone.entity
 
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import social.bigbone.api.Scope
 
@@ -10,22 +9,12 @@ class ScopeTest {
     fun toStringTest() {
         Scope(Scope.Name.READ).toString() shouldBeEqualTo "read"
         Scope(Scope.Name.READ, Scope.Name.WRITE).toString() shouldBeEqualTo "read write"
-        Scope(Scope.Name.ALL).toString() shouldBeEqualTo "read write follow"
-        Scope().toString() shouldBeEqualTo "read write follow"
+        Scope().toString() shouldBeEqualTo ""
     }
 
     @Test
-    fun validateSuccess() {
-        Scope().validate()
-        Scope(Scope.Name.READ).validate()
-        Scope(Scope.Name.READ, Scope.Name.WRITE).validate()
-        Scope(Scope.Name.ALL).validate()
-    }
-
-    @Test
-    fun validateDuplication() {
-        Assertions.assertThrows(java.lang.IllegalArgumentException::class.java) {
-            Scope(Scope.Name.READ, Scope.Name.READ).validate()
-        }
+    fun toStringTestWithDuplicates() {
+        Scope(Scope.Name.READ, Scope.Name.READ).toString() shouldBeEqualTo "read"
+        Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH, Scope.Name.WRITE).toString() shouldBeEqualTo "read write push"
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/entity/ScopeTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/entity/ScopeTest.kt
@@ -7,14 +7,14 @@ import social.bigbone.api.Scope
 class ScopeTest {
     @Test
     fun toStringTest() {
-        Scope(Scope.Name.READ).toString() shouldBeEqualTo "read"
-        Scope(Scope.Name.READ, Scope.Name.WRITE).toString() shouldBeEqualTo "read write"
+        Scope(Scope.READ.ALL).toString() shouldBeEqualTo "read"
+        Scope(Scope.READ.ALL, Scope.WRITE.ALL).toString() shouldBeEqualTo "read write"
         Scope().toString() shouldBeEqualTo ""
     }
 
     @Test
     fun toStringTestWithDuplicates() {
-        Scope(Scope.Name.READ, Scope.Name.READ).toString() shouldBeEqualTo "read"
-        Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH, Scope.Name.WRITE).toString() shouldBeEqualTo "read write push"
+        Scope(Scope.READ.ALL, Scope.READ.ALL).toString() shouldBeEqualTo "read"
+        Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL, Scope.WRITE.ALL).toString() shouldBeEqualTo "read write push"
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
@@ -19,7 +19,7 @@ final class Authenticator {
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 
-    private static final Scope FULL_SCOPE = new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH);
+    private static final Scope FULL_SCOPE = new Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL);
 
     private Authenticator() {
     }

--- a/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
+++ b/sample-java/src/main/java/social/bigbone/sample/Authenticator.java
@@ -19,6 +19,8 @@ final class Authenticator {
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 
+    private static final Scope FULL_SCOPE = new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH);
+
     private Authenticator() {
     }
 
@@ -65,11 +67,11 @@ final class Authenticator {
     private static Token getAccessToken(final String instanceName, final String clientId, final String clientSecret, final String email, final String password) throws BigBoneRequestException {
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
         final OAuthMethods oauthMethods = new OAuthMethods(client);
-        return oauthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, REDIRECT_URI, email, password, new Scope()).execute();
+        return oauthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, REDIRECT_URI, email, password, FULL_SCOPE).execute();
     }
 
     private static Application application(final String instanceName) throws BigBoneRequestException {
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
-        return client.apps().createApp("bigbone-sample-app", REDIRECT_URI, null, new Scope()).execute();
+        return client.apps().createApp("bigbone-sample-app", REDIRECT_URI, null, FULL_SCOPE).execute();
     }
 }

--- a/sample-java/src/main/java/social/bigbone/sample/GetAppRegistration.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetAppRegistration.java
@@ -13,7 +13,7 @@ public class GetAppRegistration {
                 "bigbone-sample-app",
                 "urn:ietf:wg:oauth:2.0:oob",
                 "",
-                new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+                new Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL)
         ).execute();
         System.out.println("client_id=" + application.getClientId());
         System.out.println("client_secret=" + application.getClientSecret());

--- a/sample-java/src/main/java/social/bigbone/sample/GetAppRegistration.java
+++ b/sample-java/src/main/java/social/bigbone/sample/GetAppRegistration.java
@@ -13,7 +13,7 @@ public class GetAppRegistration {
                 "bigbone-sample-app",
                 "urn:ietf:wg:oauth:2.0:oob",
                 "",
-                new Scope(Scope.Name.ALL)
+                new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
         ).execute();
         System.out.println("client_id=" + application.getClientId());
         System.out.println("client_secret=" + application.getClientSecret());

--- a/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
+++ b/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
@@ -16,7 +16,7 @@ public class OAuthGetAccessToken {
         final String redirectUri = args[3];
 
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
-        final Scope fullScope = new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH);
+        final Scope fullScope = new Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL);
         final String url = client.oauth().getOAuthUrl(clientId, redirectUri, fullScope);
         System.out.println("Open authorization page and copy code:");
         System.out.println(url);

--- a/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
+++ b/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
@@ -16,7 +16,7 @@ public class OAuthGetAccessToken {
         final String redirectUri = args[3];
 
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
-        final String url = client.oauth().getOAuthUrl(clientId, redirectUri, new Scope());
+        final String url = client.oauth().getOAuthUrl(clientId, redirectUri, new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH));
         System.out.println("Open authorization page and copy code:");
         System.out.println(url);
         System.out.println("Paste code:");

--- a/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
+++ b/sample-java/src/main/java/social/bigbone/sample/OAuthGetAccessToken.java
@@ -16,7 +16,8 @@ public class OAuthGetAccessToken {
         final String redirectUri = args[3];
 
         final MastodonClient client = new MastodonClient.Builder(instanceName).build();
-        final String url = client.oauth().getOAuthUrl(clientId, redirectUri, new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH));
+        final Scope fullScope = new Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH);
+        final String url = client.oauth().getOAuthUrl(clientId, redirectUri, fullScope);
         System.out.println("Open authorization page and copy code:");
         System.out.println(url);
         System.out.println("Paste code:");
@@ -28,7 +29,8 @@ public class OAuthGetAccessToken {
                 clientId,
                 clientSecret,
                 redirectUri,
-                authCode);
+                authCode,
+                fullScope);
 
         System.out.println("Access Token:");
         System.out.println(token.execute().getAccessToken());

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
@@ -13,6 +13,7 @@ object Authenticator {
     private const val CLIENT_SECRET = "client_secret"
     private const val ACCESS_TOKEN = "access_token"
     private const val REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
+    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
 
     fun appRegistrationIfNeeded(instanceName: String, credentialFilePath: String, useStreaming: Boolean = false): MastodonClient {
         val file = File(credentialFilePath)
@@ -72,7 +73,7 @@ object Authenticator {
     ): Token {
         val client = MastodonClient.Builder(instanceName).build()
         val oAuthMethods = OAuthMethods(client)
-        return oAuthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, REDIRECT_URI, email, password, Scope()).execute()
+        return oAuthMethods.getUserAccessTokenWithPasswordGrant(clientId, clientSecret, REDIRECT_URI, email, password, fullScope).execute()
     }
 
     private fun appRegistration(instanceName: String): Application {
@@ -80,7 +81,7 @@ object Authenticator {
         return client.apps.createApp(
             clientName = "bigbone-sample-app",
             redirectUris = REDIRECT_URI,
-            scope = Scope()
+            scope = fullScope
         ).execute()
     }
 }

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/Authenticator.kt
@@ -13,7 +13,7 @@ object Authenticator {
     private const val CLIENT_SECRET = "client_secret"
     private const val ACCESS_TOKEN = "access_token"
     private const val REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
-    private val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+    private val fullScope = Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL)
 
     fun appRegistrationIfNeeded(instanceName: String, credentialFilePath: String, useStreaming: Boolean = false): MastodonClient {
         val file = File(credentialFilePath)

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
@@ -14,7 +14,8 @@ object OAuthGetAccessToken {
         val clientSecret = args[2]
         val redirectUri = args[3]
         val client = MastodonClient.Builder(instanceName).build()
-        val url = client.oauth.getOAuthUrl(clientId, redirectUri, Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH))
+        val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+        val url = client.oauth.getOAuthUrl(clientId, redirectUri, fullScope)
         println("Open authorization page and copy code:")
         println(url)
         println("Paste code:")
@@ -24,7 +25,8 @@ object OAuthGetAccessToken {
             clientId,
             clientSecret,
             redirectUri,
-            authCode
+            authCode,
+            fullScope
         )
         println("Access Token:")
         println(token.execute().accessToken)

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
@@ -14,7 +14,7 @@ object OAuthGetAccessToken {
         val clientSecret = args[2]
         val redirectUri = args[3]
         val client = MastodonClient.Builder(instanceName).build()
-        val fullScope = Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH)
+        val fullScope = Scope(Scope.READ.ALL, Scope.WRITE.ALL, Scope.PUSH.ALL)
         val url = client.oauth.getOAuthUrl(clientId, redirectUri, fullScope)
         println("Open authorization page and copy code:")
         println(url)

--- a/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
+++ b/sample-kotlin/src/main/kotlin/social/bigbone/sample/OAuthGetAccessToken.kt
@@ -14,7 +14,7 @@ object OAuthGetAccessToken {
         val clientSecret = args[2]
         val redirectUri = args[3]
         val client = MastodonClient.Builder(instanceName).build()
-        val url = client.oauth.getOAuthUrl(clientId, redirectUri, Scope())
+        val url = client.oauth.getOAuthUrl(clientId, redirectUri, Scope(Scope.Name.READ, Scope.Name.WRITE, Scope.Name.PUSH))
         println("Open authorization page and copy code:")
         println(url)
         println("Paste code:")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.gradle.enterprise' version '3.16'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
 }
 


### PR DESCRIPTION
# Description

- makes all scope parameters in OAuth and App methods optional. Endpoints not receiving a scope parameter will default to granting "read" permission.
- removes default parameter value from Scope constructor. Users will need to define a certain scope if they want to use it. Closes #116.

- adds all scopes as defined by Mastodon, marks existing scopes FOLLOW and ALL as deprecated.
- removes all internal usage of the now deprecated ALL scope. Closes #143.

- moves deduplication of scopes from a separate function into the one building the parameter string. This avoids unnecessarily throwing an IllegalArgumentException. Closes #381.

# Type of Change

- New feature

# Breaking Changes

- Scope constructor can no longer be called without explicitly enumerating scopes that should be requested.
- `Scope.NAME` enum has been replaced with hierarchically arranged scope definitions in the class. Example: `Scope.Name.READ` becomes `Scope.READ.ALL`
- Existing `FOLLOW` scope has been removed. Use individual child scopes of `READ` and `WRITE` instead.
- Existing `ALL` scope has been removed. Use individual scopes necessary for your use case instead.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

# Mandatory Checklist

- [X] I ran `gradle check` and there were no errors reported
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally with my changes
- [X] I have added KDoc documentation to all public methods