### PR TITLE
PR template: Add check boxes to Optional Checks section

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -34,10 +34,11 @@ please list/document them here, otherwise set "None". This information will be p
 - [ ] All tests pass locally with my changes
 - [ ] I have added KDoc documentation to all public methods
 
-# Optional Things To Check
+# Optional checks
 
-The items below are some more things to check before asking other people to review your code.
+<!-- The items below are some more things to check before asking other people to review your code.
+Please delete any entry that does not apply. If none apply, please also delete this whole section. -->
 
-- In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
-- In case you added new `*Methods` classes: Did you also reference it in the `MastodonClient` main class?
-- Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?
+- [ ] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
+- [ ] In case you added new `*Methods` classes: Did you also reference it in the `MastodonClient` main class?
+- [ ] Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?


### PR DESCRIPTION
# Description

This PR adds check boxes to the “Optional checks” (slightly renamed) section of our PR template. I find myself constantly adding them anyway for new features. This should simplify it for new endpoints.