### PR TITLE
Fix broken Admin::IpBlocks kDoc links

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/admin/RxAdminIpBlockMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/admin/RxAdminIpBlockMethods.kt
@@ -21,7 +21,7 @@ class RxAdminIpBlockMethods(client: MastodonClient) {
     /**
      * Show information about all blocked IP ranges.
      * @param range optional Range for the pageable return value
-     * @see <a href="https://docs.joinmastodon.org/methods/ip_blocks/#get">Mastodon API documentation: methods/ip_blocks/#get</a>
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/ip_blocks/#get">Mastodon API documentation: admin/ip_blocks/#get</a>
      */
     @JvmOverloads
     fun getAllIpBlocks(range: Range = Range()): Single<Pageable<AdminIpBlock>> = Single.fromCallable {
@@ -31,7 +31,7 @@ class RxAdminIpBlockMethods(client: MastodonClient) {
     /**
      * Show information about a single IP block.
      * @param id The ID of the IpBlock in the database.
-     * @see <a href="https://docs.joinmastodon.org/methods/ip_blocks/#get">Mastodon API documentation: methods/ip_blocks/#get</a>
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/ip_blocks/#get">Mastodon API documentation: admin/ip_blocks/#get</a>
      */
     fun getBlockedIpRange(id: String): Single<AdminIpBlock> = Single.fromCallable {
         adminIpBlockMethods.getBlockedIpRange(id = id).execute()

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -113,6 +113,13 @@ private constructor(
     val adminDimensions: AdminDimensionMethods by lazy { AdminDimensionMethods(this) }
 
     /**
+     * Access API methods under the "admin/ip_blocks" endpoint.
+     */
+    @Suppress("unused") // public API
+    @get:JvmName("adminIpBlock")
+    val adminIpBlock: AdminIpBlockMethods by lazy { AdminIpBlockMethods(this) }
+
+    /**
      * Access API methods under the "admin/measures" endpoint.
      */
     @Suppress("unused") // public API
@@ -125,13 +132,6 @@ private constructor(
     @Suppress("unused") // public API
     @get:JvmName("adminRetention")
     val adminRetention: AdminRetentionMethods by lazy { AdminRetentionMethods(this) }
-
-    /**
-     * Access API methods under the "admin/retention" endpoint.
-     */
-    @Suppress("unused") // public API
-    @get:JvmName("adminIpBlock")
-    val adminIpBlock: AdminIpBlockMethods by lazy { AdminIpBlockMethods(this) }
 
     /**
      * Access API methods under the "announcements" endpoint.

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/admin/AdminIpBlockMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/admin/AdminIpBlockMethods.kt
@@ -18,7 +18,7 @@ class AdminIpBlockMethods(private val client: MastodonClient) {
     /**
      * Show information about all blocked IP ranges.
      * @param range optional Range for the pageable return value
-     * @see <a href="https://docs.joinmastodon.org/methods/ip_blocks/#get">Mastodon API documentation: methods/ip_blocks/#get</a>
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/ip_blocks/#get">Mastodon API documentation: admin/ip_blocks/#get</a>
      */
     @JvmOverloads
     fun getAllIpBlocks(range: Range = Range()): MastodonRequest<Pageable<AdminIpBlock>> {
@@ -32,7 +32,7 @@ class AdminIpBlockMethods(private val client: MastodonClient) {
     /**
      * Show information about a single IP block.
      * @param id The ID of the IpBlock in the database.
-     * @see <a href="https://docs.joinmastodon.org/methods/ip_blocks/#get-one">Mastodon API documentation: methods/ip_blocks/#get-one</a>
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/ip_blocks/#get-one">Mastodon API documentation: admin/ip_blocks/#get-one</a>
      */
     fun getBlockedIpRange(id: String): MastodonRequest<AdminIpBlock> {
         return client.getMastodonRequest(


### PR DESCRIPTION
# Description

I didn’t notice in #392 that some kDocs contain broken links and that the order of shortcuts in `MastodonClient` wasn’t alphabetical anymore, so this PR fixes those.

Relates to #320 

# Type of Change

- Documentation

# Breaking Changes

- None

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods