### PR TITLE
Add Admin::Reports methods

### DIFF
--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxReportMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/RxReportMethods.kt
@@ -3,7 +3,7 @@ package social.bigbone.rx
 import io.reactivex.rxjava3.core.Single
 import social.bigbone.MastodonClient
 import social.bigbone.api.entity.Report
-import social.bigbone.api.entity.Report.ReportCategory
+import social.bigbone.api.entity.data.ReportCategory
 import social.bigbone.api.method.ReportMethods
 
 /**

--- a/bigbone-rx/src/main/kotlin/social/bigbone/rx/admin/RxAdminReportMethods.kt
+++ b/bigbone-rx/src/main/kotlin/social/bigbone/rx/admin/RxAdminReportMethods.kt
@@ -1,0 +1,126 @@
+package social.bigbone.rx.admin
+
+import io.reactivex.rxjava3.core.Single
+import social.bigbone.MastodonClient
+import social.bigbone.MastodonRequest
+import social.bigbone.api.Pageable
+import social.bigbone.api.Range
+import social.bigbone.api.entity.admin.AdminReport
+import social.bigbone.api.entity.data.ReportCategory
+import social.bigbone.api.method.InstanceMethods
+import social.bigbone.api.method.admin.AdminReportMethods
+
+/**
+ * Reactive implementation of [AdminReportMethods].
+ *
+ * Perform moderation actions with reports.
+ *
+ * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/">Mastodon admin/reports API methods</a>
+ */
+class RxAdminReportMethods(client: MastodonClient) {
+
+    private val adminReportMethods = AdminReportMethods(client)
+
+    /**
+     * View information about all reports.
+     *
+     * @param range optional Range for the pageable return value.
+     * @param resolved Filter for resolved reports?
+     * @param filedByAccountId Filter for reports filed by this account.
+     * @param targetingAccountId Filter for reports targeting this account.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#get">Mastodon API documentation: admin/reports/#get</a>
+     */
+    @JvmOverloads
+    fun getAllReports(
+        range: Range = Range(),
+        resolved: Boolean? = null,
+        filedByAccountId: String? = null,
+        targetingAccountId: String? = null
+    ): Single<Pageable<AdminReport>> = Single.fromCallable {
+        adminReportMethods.getAllReports(
+            range = range,
+            resolved = resolved,
+            filedByAccountId = filedByAccountId,
+            targetingAccountId = targetingAccountId
+        ).execute()
+    }
+
+    /**
+     * View information about a single report.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#get-one">Mastodon API documentation: admin/reports/#get-one</a>
+     */
+    fun getReport(reportId: String): Single<AdminReport> = Single.fromCallable {
+        adminReportMethods.getReport(reportId).execute()
+    }
+
+    /**
+     * Change metadata for a report.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     * @param updatedCategory Change the classification of the report to one of [ReportCategory].
+     * @param violationRuleIds For [ReportCategory.VIOLATION] category reports, specify the ID of the exact rules broken.
+     * Rules and their IDs are available via  [InstanceMethods.getRules] and [InstanceMethods.getInstance].
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#update">Mastodon API documentation: admin/reports/#update</a>
+     */
+    @JvmOverloads
+    fun updateReportMetadata(
+        reportId: String,
+        updatedCategory: ReportCategory,
+        violationRuleIds: List<Int>? = null
+    ): Single<MastodonRequest<AdminReport>> = Single.fromCallable {
+        adminReportMethods.updateReportMetadata(
+            reportId = reportId,
+            updatedCategory = updatedCategory,
+            violationRuleIds = violationRuleIds
+        )
+    }
+
+    /**
+     * Claim the handling of this report to yourself.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#assign_to_self">Mastodon API documentation: admin/reports/#assign_to_self</a>
+     */
+    fun assignReportToSelf(reportId: String): Single<AdminReport> = Single.fromCallable {
+        adminReportMethods.assignReportToSelf(reportId).execute()
+    }
+
+    /**
+     * Unassign a report so that someone else can claim it.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#unassign">Mastodon API documentation: admin/reports/#unassign</a>
+     */
+    fun unassignReport(reportId: String): Single<AdminReport> = Single.fromCallable {
+        adminReportMethods.unassignReport(reportId).execute()
+    }
+
+    /**
+     * Mark a report as resolved with no futher action taken.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#resolve">Mastodon API documentation: admin/reports/#resolve</a>
+     */
+    fun resolveReport(reportId: String): Single<AdminReport> = Single.fromCallable {
+        adminReportMethods.resolveReport(reportId).execute()
+    }
+
+    /**
+     * Reopen a currently closed report, if it is closed.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#reopen">Mastodon API documentation: admin/reports/#reopen</a>
+     */
+    fun reopenReport(reportId: String): Single<AdminReport> = Single.fromCallable {
+        adminReportMethods.reopenReport(reportId).execute()
+    }
+}

--- a/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonClient.kt
@@ -73,6 +73,7 @@ import social.bigbone.api.method.admin.AdminDomainBlockMethods
 import social.bigbone.api.method.admin.AdminEmailDomainBlockMethods
 import social.bigbone.api.method.admin.AdminIpBlockMethods
 import social.bigbone.api.method.admin.AdminMeasureMethods
+import social.bigbone.api.method.admin.AdminReportMethods
 import social.bigbone.api.method.admin.AdminRetentionMethods
 import social.bigbone.api.method.admin.AdminTrendMethods
 import social.bigbone.extension.emptyRequestBody
@@ -166,6 +167,13 @@ private constructor(
     @Suppress("unused") // public API
     @get:JvmName("adminMeasures")
     val adminMeasures: AdminMeasureMethods by lazy { AdminMeasureMethods(this) }
+
+    /**
+     * Access API methods under the "admin/reports" endpoint.
+     */
+    @Suppress("unused") // public API
+    @get:JvmName("adminReports")
+    val adminReports: AdminReportMethods by lazy { AdminReportMethods(this) }
 
     /**
      * Access API methods under the "admin/retention" endpoint.

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Report.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Report.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 import social.bigbone.DateTimeSerializer
 import social.bigbone.PrecisionDateTime
 import social.bigbone.PrecisionDateTime.InvalidPrecisionDateTime
+import social.bigbone.api.entity.data.ReportCategory
 
 /**
  * Reports filed against users and/or statuses, to be taken action on by moderators.
@@ -74,19 +75,4 @@ data class Report(
      */
     @SerialName("target_account")
     val targetAccount: Account
-) {
-    /**
-     * Specify the typology of category among spam, violation or other.
-     */
-    @Serializable
-    enum class ReportCategory {
-        @SerialName("spam")
-        SPAM,
-
-        @SerialName("violation")
-        VIOLATION,
-
-        @SerialName("other")
-        OTHER
-    }
-}
+)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/Role.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/Role.kt
@@ -17,20 +17,20 @@ data class Role(
      * The ID of the Role in the database.
      */
     @SerialName("id")
-    val id: Int,
+    val id: Int = 0,
 
     /**
      * The name of the role.
      */
     @SerialName("name")
-    val name: String,
+    val name: String = "",
 
     /**
      * The hex code assigned to this role.
      * If no hex code is assigned, the string will be empty.
      */
     @SerialName("color")
-    val color: String,
+    val color: String = "",
 
     /**
      * A bitmask that represents the sum of all permissions granted to the role.
@@ -39,13 +39,13 @@ data class Role(
      * For convenience, use [getParsedPermissions] to directly get a list of [Permission]s seen in this field.
      */
     @SerialName("permissions")
-    val rawPermissions: Int,
+    val rawPermissions: Int = 0,
 
     /**
      * Whether the role is publicly visible as a badge on user profiles.
      */
     @SerialName("highlighted")
-    val highlighted: Boolean,
+    val highlighted: Boolean = false,
 
     /**
      * When the role was first assigned.

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/admin/AdminAccount.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/admin/AdminAccount.kt
@@ -17,13 +17,13 @@ data class AdminAccount(
      * String cast from an Integer, but not guaranteed to be a number.
      */
     @SerialName("id")
-    val id: String,
+    val id: String = "",
 
     /**
      * The username of the account.
      */
     @SerialName("username")
-    val username: String,
+    val username: String = "",
 
     /**
      * The domain of the account, if it is remote.
@@ -43,7 +43,7 @@ data class AdminAccount(
      * The email address associated with the account.
      */
     @SerialName("email")
-    val email: String,
+    val email: String = "",
 
     /**
      * The IP address last used to log in to this account.
@@ -55,43 +55,43 @@ data class AdminAccount(
      * All known IP addresses associated with this account.
      */
     @SerialName("ips")
-    val adminIPs: List<IP>,
+    val adminIPs: List<IP> = emptyList(),
 
     /**
      * The current role of the account.
      */
     @SerialName("role")
-    val role: Role,
+    val role: Role = Role(),
 
     /**
      * Whether the account has confirmed their email address.
      */
     @SerialName("confirmed")
-    val confirmed: Boolean,
+    val confirmed: Boolean = false,
 
     /**
      * Whether the account is currently suspended.
      */
     @SerialName("suspended")
-    val suspended: Boolean,
+    val suspended: Boolean = false,
 
     /**
      * Whether the account is currently silenced.
      */
     @SerialName("silenced")
-    val silenced: Boolean,
+    val silenced: Boolean = false,
 
     /**
      * Whether the account is currently disabled.
      */
     @SerialName("disabled")
-    val disabled: Boolean,
+    val disabled: Boolean = false,
 
     /**
      * Whether the account is currently approved.
      */
     @SerialName("approved")
-    val approved: Boolean,
+    val approved: Boolean = false,
 
     /**
      * Whether these account’s post are currently flagged sensitive.
@@ -117,7 +117,7 @@ data class AdminAccount(
      * User-level information about the account.
      */
     @SerialName("account")
-    val account: Account,
+    val account: Account = Account(),
 
     /**
      * The ID of the Application that created this account, if applicable.
@@ -142,7 +142,7 @@ data class AdminAccount(
          * The IP address.
          */
         @SerialName("ip")
-        val ipAddress: String,
+        val ipAddress: String = "",
 
         /**
          * The timestamp of when the IP address was last used for this account.

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/admin/AdminReport.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/admin/AdminReport.kt
@@ -1,0 +1,108 @@
+package social.bigbone.api.entity.admin
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import social.bigbone.DateTimeSerializer
+import social.bigbone.PrecisionDateTime
+import social.bigbone.api.entity.Rule
+import social.bigbone.api.entity.Status
+import social.bigbone.api.entity.data.ReportCategory
+
+/**
+ * Admin-level information about a filed report.
+ *
+ * @see <a href="https://docs.joinmastodon.org/entities/Admin_Report/">Mastodon API Admin::Report</a>
+ */
+@Serializable
+data class AdminReport(
+    /**
+     * The ID of the report in the database.
+     * String cast from an integer, but not guaranteed to be a number.
+     */
+    @SerialName("id")
+    val id: String,
+
+    /**
+     * Whether an action was taken to resolve this report.
+     */
+    @SerialName("action_taken")
+    val actionTaken: Boolean,
+
+    /**
+     * When an action was taken, if this report is currently unresolved.
+     */
+    @SerialName("action_taken_at")
+    @Serializable(with = DateTimeSerializer::class)
+    val actionTakenAt: PrecisionDateTime = PrecisionDateTime.InvalidPrecisionDateTime.Unavailable,
+
+    /**
+     * The category under which the report is classified.
+     * @see ReportCategory
+     */
+    @SerialName("category")
+    val category: ReportCategory,
+
+    /**
+     * An optional reason for reporting.
+     */
+    @SerialName("comment")
+    val comment: String? = null,
+
+    /**
+     * Whether the report was forwarded to a remote instance.
+     */
+    @SerialName("forwarded")
+    val forwarded: Boolean,
+
+    /**
+     * The time the report was filed.
+     */
+    @SerialName("created_at")
+    @Serializable(with = DateTimeSerializer::class)
+    val createdAt: PrecisionDateTime = PrecisionDateTime.InvalidPrecisionDateTime.Unavailable,
+
+    /**
+     * The time of last action on this report.
+     */
+    @SerialName("updated_at")
+    @Serializable(with = DateTimeSerializer::class)
+    val updatedAt: PrecisionDateTime = PrecisionDateTime.InvalidPrecisionDateTime.Unavailable,
+
+    /**
+     * The account which filed the report.
+     */
+    @SerialName("account")
+    val reportCreator: AdminAccount,
+
+    /**
+     * The account being reported.
+     */
+    @SerialName("target_account")
+    val reportedAccount: AdminAccount,
+
+    /**
+     * The account of the moderator assigned to this report.
+     * May be null if no moderator was assigned.
+     */
+    @SerialName("assigned_account")
+    val assignedModerator: AdminAccount?,
+
+    /**
+     * The account of the moderator who handled the report.
+     * May be null if no action has been taken on this report by any moderator yet.
+     */
+    @SerialName("action_taken_by_account")
+    val handledBy: AdminAccount?,
+
+    /**
+     * Statuses attached to the report, for context.
+     */
+    @SerialName("statuses")
+    val attachedStatuses: List<Status>,
+
+    /**
+     * Rules attached to the report, for context.
+     */
+    @SerialName("rules")
+    val attachedRules: List<Rule>
+)

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/admin/AdminReport.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/admin/AdminReport.kt
@@ -20,13 +20,13 @@ data class AdminReport(
      * String cast from an integer, but not guaranteed to be a number.
      */
     @SerialName("id")
-    val id: String,
+    val id: String = "",
 
     /**
      * Whether an action was taken to resolve this report.
      */
     @SerialName("action_taken")
-    val actionTaken: Boolean,
+    val actionTaken: Boolean = false,
 
     /**
      * When an action was taken, if this report is currently unresolved.
@@ -40,7 +40,7 @@ data class AdminReport(
      * @see ReportCategory
      */
     @SerialName("category")
-    val category: ReportCategory,
+    val category: ReportCategory = ReportCategory.OTHER,
 
     /**
      * An optional reason for reporting.
@@ -52,7 +52,7 @@ data class AdminReport(
      * Whether the report was forwarded to a remote instance.
      */
     @SerialName("forwarded")
-    val forwarded: Boolean,
+    val forwarded: Boolean = false,
 
     /**
      * The time the report was filed.
@@ -72,37 +72,37 @@ data class AdminReport(
      * The account which filed the report.
      */
     @SerialName("account")
-    val reportCreator: AdminAccount,
+    val reportCreator: AdminAccount = AdminAccount(),
 
     /**
      * The account being reported.
      */
     @SerialName("target_account")
-    val reportedAccount: AdminAccount,
+    val reportedAccount: AdminAccount = AdminAccount(),
 
     /**
      * The account of the moderator assigned to this report.
      * May be null if no moderator was assigned.
      */
     @SerialName("assigned_account")
-    val assignedModerator: AdminAccount?,
+    val assignedModerator: AdminAccount? = null,
 
     /**
      * The account of the moderator who handled the report.
      * May be null if no action has been taken on this report by any moderator yet.
      */
     @SerialName("action_taken_by_account")
-    val handledBy: AdminAccount?,
+    val handledBy: AdminAccount? = null,
 
     /**
      * Statuses attached to the report, for context.
      */
     @SerialName("statuses")
-    val attachedStatuses: List<Status>,
+    val attachedStatuses: List<Status> = emptyList(),
 
     /**
      * Rules attached to the report, for context.
      */
     @SerialName("rules")
-    val attachedRules: List<Rule>
+    val attachedRules: List<Rule> = emptyList()
 )

--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/data/ReportCategory.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/data/ReportCategory.kt
@@ -1,0 +1,25 @@
+package social.bigbone.api.entity.data
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import social.bigbone.api.entity.Report
+import social.bigbone.api.entity.admin.AdminReport
+
+/**
+ * The category under which a [Report] (or [AdminReport]) is classified.
+ */
+@Serializable
+enum class ReportCategory {
+    @SerialName("spam")
+    SPAM,
+
+    @SerialName("violation")
+    VIOLATION,
+
+    @SerialName("other")
+    OTHER;
+
+    @OptIn(ExperimentalSerializationApi::class)
+    val apiName: String get() = serializer().descriptor.getElementName(ordinal)
+}

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/ReportMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/ReportMethods.kt
@@ -4,7 +4,7 @@ import social.bigbone.MastodonClient
 import social.bigbone.MastodonRequest
 import social.bigbone.Parameters
 import social.bigbone.api.entity.Report
-import social.bigbone.api.entity.Report.ReportCategory
+import social.bigbone.api.entity.data.ReportCategory
 import social.bigbone.api.exception.BigBoneRequestException
 
 /**

--- a/bigbone/src/main/kotlin/social/bigbone/api/method/admin/AdminReportMethods.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/method/admin/AdminReportMethods.kt
@@ -1,0 +1,146 @@
+package social.bigbone.api.method.admin
+
+import social.bigbone.MastodonClient
+import social.bigbone.MastodonClient.Method
+import social.bigbone.MastodonRequest
+import social.bigbone.Parameters
+import social.bigbone.api.Pageable
+import social.bigbone.api.Range
+import social.bigbone.api.entity.admin.AdminReport
+import social.bigbone.api.entity.data.ReportCategory
+import social.bigbone.api.method.InstanceMethods
+
+/**
+ * Perform moderation actions with reports.
+ *
+ * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/">Mastodon admin/reports API methods</a>
+ */
+class AdminReportMethods(val client: MastodonClient) {
+
+    internal val endpoint = "api/v1/admin/reports"
+
+    /**
+     * View information about all reports.
+     *
+     * @param range optional Range for the pageable return value.
+     * @param resolved Filter for resolved reports?
+     * @param filedByAccountId Filter for reports filed by this account.
+     * @param targetingAccountId Filter for reports targeting this account.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#get">Mastodon API documentation: admin/reports/#get</a>
+     */
+    @JvmOverloads
+    fun getAllReports(
+        range: Range = Range(),
+        resolved: Boolean? = null,
+        filedByAccountId: String? = null,
+        targetingAccountId: String? = null
+    ): MastodonRequest<Pageable<AdminReport>> {
+        return client.getPageableMastodonRequest(
+            endpoint = endpoint,
+            method = Method.GET,
+            parameters = Parameters().apply {
+                resolved?.let { append("resolved", resolved) }
+                filedByAccountId?.let { append("account_id", filedByAccountId) }
+                targetingAccountId?.let { append("target_account_id", targetingAccountId) }
+                range.toParameters(this)
+            }
+        )
+    }
+
+    /**
+     * View information about a single report.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#get-one">Mastodon API documentation: admin/reports/#get-one</a>
+     */
+    fun getReport(reportId: String): MastodonRequest<AdminReport> {
+        return client.getMastodonRequest(
+            endpoint = "$endpoint/$reportId",
+            method = Method.GET
+        )
+    }
+
+    /**
+     * Change metadata for a report.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     * @param updatedCategory Change the classification of the report to one of [ReportCategory].
+     * @param violationRuleIds For [ReportCategory.VIOLATION] category reports, specify the ID of the exact rules broken.
+     * Rules and their IDs are available via  [InstanceMethods.getRules] and [InstanceMethods.getInstance].
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#update">Mastodon API documentation: admin/reports/#update</a>
+     */
+    @JvmOverloads
+    fun updateReportMetadata(
+        reportId: String,
+        updatedCategory: ReportCategory,
+        violationRuleIds: List<Int>? = null
+    ): MastodonRequest<AdminReport> {
+        return client.getMastodonRequest(
+            endpoint = "$endpoint/$reportId",
+            method = Method.PUT,
+            parameters = Parameters().apply {
+                append("category", updatedCategory.apiName)
+                violationRuleIds?.let { append("rule_ids", violationRuleIds) }
+            }
+        )
+    }
+
+    /**
+     * Claim the handling of this report to yourself.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#assign_to_self">Mastodon API documentation: admin/reports/#assign_to_self</a>
+     */
+    fun assignReportToSelf(reportId: String): MastodonRequest<AdminReport> {
+        return client.getMastodonRequest(
+            endpoint = "$endpoint/$reportId/assign_to_self",
+            method = Method.POST
+        )
+    }
+
+    /**
+     * Unassign a report so that someone else can claim it.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#unassign">Mastodon API documentation: admin/reports/#unassign</a>
+     */
+    fun unassignReport(reportId: String): MastodonRequest<AdminReport> {
+        return client.getMastodonRequest(
+            endpoint = "$endpoint/$reportId/unassign",
+            method = Method.POST
+        )
+    }
+
+    /**
+     * Mark a report as resolved with no futher action taken.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#resolve">Mastodon API documentation: admin/reports/#resolve</a>
+     */
+    fun resolveReport(reportId: String): MastodonRequest<AdminReport> {
+        return client.getMastodonRequest(
+            endpoint = "$endpoint/$reportId/resolve",
+            method = Method.POST
+        )
+    }
+
+    /**
+     * Reopen a currently closed report, if it is closed.
+     *
+     * @param reportId The ID of the [AdminReport] in the database.
+     *
+     * @see <a href="https://docs.joinmastodon.org/methods/admin/reports/#reopen">Mastodon API documentation: admin/reports/#reopen</a>
+     */
+    fun reopenReport(reportId: String): MastodonRequest<AdminReport> {
+        return client.getMastodonRequest(
+            endpoint = "$endpoint/$reportId/reopen",
+            method = Method.POST
+        )
+    }
+}

--- a/bigbone/src/test/assets/admin_reports_assign_to_self_success.json
+++ b/bigbone/src/test/assets/admin_reports_assign_to_self_success.json
@@ -1,0 +1,25 @@
+{
+  "id": "3",
+  "action_taken": false,
+  "action_taken_at": null,
+  "category": "other",
+  "comment": "",
+  "forwarded": false,
+  "created_at": "2022-09-09T21:21:01.204Z",
+  "updated_at": "2022-09-11T14:39:01.531Z",
+  "assigned_account": {
+    "id": "108965218747268792",
+    "username": "admin",
+    "domain": null,
+    "created_at": "2022-09-08T22:48:07.985Z",
+    "email": "admin@mastodon.local",
+    "account": {
+      "id": "108965218747268792",
+      "username": "admin",
+      "acct": "admin"
+    }
+  },
+  "action_taken_by_account": null,
+  "statuses": [],
+  "rules": []
+}

--- a/bigbone/src/test/assets/admin_reports_get_all_reports_success.json
+++ b/bigbone/src/test/assets/admin_reports_get_all_reports_success.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "3",
+    "action_taken": false,
+    "action_taken_at": null,
+    "category": "spam",
+    "comment": "",
+    "forwarded": false,
+    "created_at": "2022-09-09T21:19:23.085Z",
+    "updated_at": "2022-09-09T21:19:23.085Z",
+    "account": {
+      "id": "108965218747268792",
+      "username": "admin",
+      "domain": null,
+      "created_at": "2022-09-08T22:48:07.985Z",
+      "email": "admin@mastodon.local",
+      "account": {
+        "id": "108965218747268792",
+        "username": "admin",
+        "acct": "admin"
+      }
+    },
+    "target_account": {
+      "id": "108965430868193066",
+      "username": "goody",
+      "domain": null,
+      "created_at": "2022-09-08T23:42:04.731Z",
+      "email": "goody@mastodon.local",
+      "account": {
+        "id": "108965430868193066",
+        "username": "goody",
+        "acct": "goody"
+      }
+    },
+    "assigned_account": null,
+    "action_taken_by_account": null,
+    "statuses": [],
+    "rules": []
+  }
+]

--- a/bigbone/src/test/assets/admin_reports_get_single_report_success.json
+++ b/bigbone/src/test/assets/admin_reports_get_single_report_success.json
@@ -1,0 +1,49 @@
+{
+  "id": "2",
+  "action_taken": true,
+  "action_taken_at": "2022-09-09T21:38:54.679Z",
+  "category": "spam",
+  "comment": "",
+  "forwarded": false,
+  "created_at": "2022-09-09T21:19:44.021Z",
+  "updated_at": "2022-09-09T21:38:54.681Z",
+  "account": {
+    "id": "108965218747268792",
+    "username": "admin",
+    "domain": null,
+    "created_at": "2022-09-08T22:48:07.985Z",
+    "email": "admin@mastodon.local",
+    "account": {
+      "id": "108965218747268792",
+      "username": "admin",
+      "acct": "admin"
+    }
+  },
+  "target_account": {
+    "id": "108965430868193066",
+    "username": "goody",
+    "domain": null,
+    "created_at": "2022-09-08T23:42:04.731Z",
+    "email": "goody@mastodon.local",
+    "account": {
+      "id": "108965430868193066",
+      "username": "goody",
+      "acct": "goody"
+    }
+  },
+  "assigned_account": null,
+  "action_taken_by_account": {
+    "id": "108965218747268792",
+    "username": "admin",
+    "domain": null,
+    "created_at": "2022-09-08T22:48:07.985Z",
+    "email": "admin@mastodon.local",
+    "account": {
+      "id": "108965218747268792",
+      "username": "admin",
+      "acct": "admin"
+    }
+  },
+  "statuses": [],
+  "rules": []
+}

--- a/bigbone/src/test/assets/admin_reports_reopen_success.json
+++ b/bigbone/src/test/assets/admin_reports_reopen_success.json
@@ -1,0 +1,10 @@
+{
+  "id": "2",
+  "action_taken": false,
+  "action_taken_at": null,
+  "category": "spam",
+  "comment": "",
+  "forwarded": false,
+  "created_at": "2022-09-09T21:19:44.021Z",
+  "updated_at": "2022-09-11T14:42:21.855Z"
+}

--- a/bigbone/src/test/assets/admin_reports_resolve_success.json
+++ b/bigbone/src/test/assets/admin_reports_resolve_success.json
@@ -1,0 +1,10 @@
+{
+  "id": "2",
+  "action_taken": true,
+  "action_taken_at": "2022-09-11T14:46:22.936Z",
+  "category": "spam",
+  "comment": "",
+  "forwarded": false,
+  "created_at": "2022-09-09T21:19:44.021Z",
+  "updated_at": "2022-09-11T14:46:22.945Z"
+}

--- a/bigbone/src/test/assets/admin_reports_unassign_success.json
+++ b/bigbone/src/test/assets/admin_reports_unassign_success.json
@@ -1,0 +1,14 @@
+{
+  "id": "3",
+  "action_taken": false,
+  "action_taken_at": null,
+  "category": "other",
+  "comment": "",
+  "forwarded": false,
+  "created_at": "2022-09-09T21:21:01.204Z",
+  "updated_at": "2022-09-11T14:39:01.531Z",
+  "assigned_account": null,
+  "action_taken_by_account": null,
+  "statuses": [],
+  "rules": []
+}

--- a/bigbone/src/test/assets/admin_reports_update_report_success.json
+++ b/bigbone/src/test/assets/admin_reports_update_report_success.json
@@ -1,0 +1,7 @@
+{
+  "id": "3",
+  "action_taken": false,
+  "action_taken_at": null,
+  "category": "other",
+  "rules": []
+}

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/ReportMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/ReportMethodsTest.kt
@@ -4,7 +4,7 @@ import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldContainIgnoringCase
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import social.bigbone.api.entity.Report.ReportCategory
+import social.bigbone.api.entity.data.ReportCategory
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.testtool.MockClient
 

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/admin/AdminReportMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/admin/AdminReportMethodsTest.kt
@@ -1,0 +1,272 @@
+package social.bigbone.api.method.admin
+
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeNullOrEmpty
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import social.bigbone.Parameters
+import social.bigbone.PrecisionDateTime.InvalidPrecisionDateTime
+import social.bigbone.PrecisionDateTime.ValidPrecisionDateTime.ExactTime
+import social.bigbone.api.Range
+import social.bigbone.api.entity.data.ReportCategory
+import social.bigbone.testtool.MockClient
+import java.time.Instant
+
+class AdminReportMethodsTest {
+
+    @Test
+    fun `Given client returning success, when getting all reports, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_get_all_reports_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+        val range = Range(limit = 23, minId = "42", maxId = "1337")
+        val resolved = false
+        val filedByAccountId = null
+        val targetingAccountId = null
+
+        val adminReports = adminReportMethods.getAllReports(
+            range = range,
+            resolved = resolved,
+            filedByAccountId = filedByAccountId,
+            targetingAccountId = targetingAccountId
+        ).execute()
+
+        with(adminReports.part) {
+            shouldHaveSize(1)
+
+            with(first()) {
+                id shouldBeEqualTo "3"
+                actionTaken.shouldBeFalse()
+                actionTakenAt shouldBeEqualTo InvalidPrecisionDateTime.Unavailable
+                category shouldBeEqualTo ReportCategory.SPAM
+                comment.shouldBeNullOrEmpty()
+                forwarded.shouldBeFalse()
+                createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-09T21:19:23.085Z"))
+                updatedAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-09T21:19:23.085Z"))
+
+                with(reportCreator) {
+                    id shouldBeEqualTo "108965218747268792"
+                    username shouldBeEqualTo "admin"
+                    domain.shouldBeNull()
+                    email shouldBeEqualTo "admin@mastodon.local"
+                    createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-08T22:48:07.985Z"))
+                    with(account) {
+                        id shouldBeEqualTo "108965218747268792"
+                        username shouldBeEqualTo "admin"
+                        acct shouldBeEqualTo "admin"
+                    }
+                }
+
+                with(reportedAccount) {
+                    id shouldBeEqualTo "108965430868193066"
+                    username shouldBeEqualTo "goody"
+                    domain.shouldBeNull()
+                    createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-08T23:42:04.731Z"))
+                    email shouldBeEqualTo "goody@mastodon.local"
+                }
+
+                assignedModerator.shouldBeNull()
+                handledBy.shouldBeNull()
+                attachedStatuses.shouldBeEmpty()
+                attachedRules.shouldBeEmpty()
+            }
+        }
+        val parametersCapturingSlot = slot<Parameters>()
+        verify {
+            client.get(
+                path = adminReportMethods.endpoint,
+                query = capture(parametersCapturingSlot)
+            )
+        }
+        with(parametersCapturingSlot.captured) {
+            toQuery() shouldBeEqualTo "resolved=false" +
+                "&max_id=1337" +
+                "&min_id=42" +
+                "&limit=23"
+        }
+    }
+
+    @Test
+    fun `Given client returning success, when getting a specific report, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_get_single_report_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+
+        val adminReport = adminReportMethods.getReport(
+            reportId = "1234"
+        ).execute()
+
+        with(adminReport) {
+            id shouldBeEqualTo "2"
+            actionTaken.shouldBeTrue()
+            actionTakenAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-09T21:38:54.679Z"))
+            category shouldBeEqualTo ReportCategory.SPAM
+            comment.shouldBeNullOrEmpty()
+            forwarded.shouldBeFalse()
+            createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-09T21:19:44.021Z"))
+            updatedAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-09T21:38:54.681Z"))
+
+            with(reportCreator) {
+                id shouldBeEqualTo "108965218747268792"
+                username shouldBeEqualTo "admin"
+                domain.shouldBeNull()
+                email shouldBeEqualTo "admin@mastodon.local"
+                createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-08T22:48:07.985Z"))
+                with(account) {
+                    id shouldBeEqualTo "108965218747268792"
+                    username shouldBeEqualTo "admin"
+                    acct shouldBeEqualTo "admin"
+                }
+            }
+
+            with(reportedAccount) {
+                id shouldBeEqualTo "108965430868193066"
+                username shouldBeEqualTo "goody"
+                domain.shouldBeNull()
+                createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-08T23:42:04.731Z"))
+                email shouldBeEqualTo "goody@mastodon.local"
+            }
+
+            assignedModerator.shouldBeNull()
+
+            with(handledBy) {
+                shouldNotBeNull()
+                id shouldBeEqualTo "108965218747268792"
+                username shouldBeEqualTo "admin"
+                domain.shouldBeNull()
+                email shouldBeEqualTo "admin@mastodon.local"
+                createdAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-08T22:48:07.985Z"))
+                with(account) {
+                    id shouldBeEqualTo "108965218747268792"
+                    username shouldBeEqualTo "admin"
+                    acct shouldBeEqualTo "admin"
+                }
+            }
+            attachedStatuses.shouldBeEmpty()
+            attachedRules.shouldBeEmpty()
+        }
+        verify {
+            client.get(
+                path = "${adminReportMethods.endpoint}/1234",
+                query = null
+            )
+        }
+    }
+
+    @Test
+    fun `Given client returning success, when updating a report, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_update_report_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+
+        val adminReport = adminReportMethods.updateReportMetadata(
+            reportId = "1234",
+            updatedCategory = ReportCategory.OTHER,
+            violationRuleIds = null
+        ).execute()
+
+        with(adminReport) {
+            id shouldBeEqualTo "3"
+            actionTaken.shouldBeFalse()
+            actionTakenAt shouldBeEqualTo InvalidPrecisionDateTime.Unavailable
+            category shouldBeEqualTo ReportCategory.OTHER
+            attachedRules.shouldBeEmpty()
+        }
+        val parametersCapturingSlot = slot<Parameters>()
+        verify {
+            client.put(
+                path = "${adminReportMethods.endpoint}/1234",
+                body = capture(parametersCapturingSlot)
+            )
+        }
+        with(parametersCapturingSlot.captured) {
+            toQuery() shouldBeEqualTo "category=other"
+        }
+    }
+
+    @Test
+    fun `Given client returning success, when assigning report to self, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_assign_to_self_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+
+        val adminReport = adminReportMethods.assignReportToSelf(
+            reportId = "1234"
+        ).execute()
+
+        with(adminReport) {
+            assignedModerator.shouldNotBeNull()
+        }
+        verify {
+            client.post(
+                path = "${adminReportMethods.endpoint}/1234/assign_to_self",
+                body = null
+            )
+        }
+    }
+
+    @Test
+    fun `Given client returning success, when unassigning report, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_unassign_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+
+        val adminReport = adminReportMethods.unassignReport(
+            reportId = "1234"
+        ).execute()
+
+        with(adminReport) {
+            assignedModerator.shouldBeNull()
+        }
+        verify {
+            client.post(
+                path = "${adminReportMethods.endpoint}/1234/unassign",
+                body = null
+            )
+        }
+    }
+
+    @Test
+    fun `Given client returning success, when resolving report, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_resolve_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+
+        val adminReport = adminReportMethods.resolveReport(
+            reportId = "1234"
+        ).execute()
+
+        with(adminReport) {
+            actionTaken.shouldBeTrue()
+            actionTakenAt shouldBeEqualTo ExactTime(Instant.parse("2022-09-11T14:46:22.936Z"))
+        }
+        verify {
+            client.post(
+                path = "${adminReportMethods.endpoint}/1234/resolve",
+                body = null
+            )
+        }
+    }
+
+    @Test
+    fun `Given client returning success, when reopening report, then call correct endpoint and parse response`() {
+        val client = MockClient.mock("admin_reports_reopen_success.json")
+        val adminReportMethods = AdminReportMethods(client)
+
+        val adminReport = adminReportMethods.reopenReport(
+            reportId = "1234"
+        ).execute()
+
+        with(adminReport) {
+            actionTaken.shouldBeFalse()
+            actionTakenAt shouldBeEqualTo InvalidPrecisionDateTime.Unavailable
+        }
+        verify {
+            client.post(
+                path = "${adminReportMethods.endpoint}/1234/reopen",
+                body = null
+            )
+        }
+    }
+}

--- a/docs/api-coverage/admin/reports.md
+++ b/docs/api-coverage/admin/reports.md
@@ -10,12 +10,12 @@ nav_order: 3
 
 <a href="https://docs.joinmastodon.org/methods/admin/reports/" target="_blank">https://docs.joinmastodon.org/methods/admin/reports/</a>
 
-| Method                                          | Description             | Status | Comments | 
-|-------------------------------------------------|-------------------------|--------|----------|
-| `GET /api/v1/admin/reports`                     | View all reports        | 🔴     |          |
-| `GET /api/v1/admin/reports/:id`                 | View a single report    | 🔴     |          |
-| `PUT /api/v1/admin/reports/:id`                 | Update a report         | 🔴     |          |
-| `POST /api/v1/admin/reports/:id/assign_to_self` | Assign report to self   | 🔴     |          |
-| `POST /api/v1/admin/reports/:id/unassign`       | Unassign report         | 🔴     |          |
-| `POST /api/v1/admin/reports/:id/resolve`        | Mark report as resolved | 🔴     |          |
-| `POST /api/v1/admin/reports/:id/reopen`         | Reopen a closed report  | 🔴     |          |
+| Method                                          | Description             |              Status               | Comments         | 
+|-------------------------------------------------|-------------------------|:---------------------------------:|------------------|
+| `GET /api/v1/admin/reports`                     | View all reports        | <img src="/assets/green16.png" /> | Fully supported. |
+| `GET /api/v1/admin/reports/:id`                 | View a single report    | <img src="/assets/green16.png" /> | Fully supported. |
+| `PUT /api/v1/admin/reports/:id`                 | Update a report         | <img src="/assets/green16.png" /> | Fully supported. |
+| `POST /api/v1/admin/reports/:id/assign_to_self` | Assign report to self   | <img src="/assets/green16.png" /> | Fully supported. |
+| `POST /api/v1/admin/reports/:id/unassign`       | Unassign report         | <img src="/assets/green16.png" /> | Fully supported. |
+| `POST /api/v1/admin/reports/:id/resolve`        | Mark report as resolved | <img src="/assets/green16.png" /> | Fully supported. |
+| `POST /api/v1/admin/reports/:id/reopen`         | Reopen a closed report  | <img src="/assets/green16.png" /> | Fully supported. |


### PR DESCRIPTION
# Description

Adds support for admin-only Reports methods to handle existing reports.

Closes #325 .

# Type of Change

- New feature
- Documentation

# Breaking Changes

- We moved `Report.ReportCategory` from `social.bigbone.api.entity.Report` to its own file in `social.bigbone.api.entity.data.ReportCategory`.

# How Has This Been Tested?

New unit tests

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods

# Optional checks

- [x] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
- [x] In case you added new `*Methods` classes: Did you also reference it in the `MastodonClient` main class?
- [x] Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?
