### PR TITLE
Make error details returned by server available in BigBoneRequestException

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/MastodonRequest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import okhttp3.Response
+import social.bigbone.api.entity.Error
 import social.bigbone.api.exception.BigBoneRequestException
 import social.bigbone.extension.toPageable
 
@@ -80,8 +81,11 @@ class MastodonRequest<T>(
                 throw BigBoneRequestException("Successful response could not be parsed", e)
             }
         } else {
+            val error = response.body?.string()?.let {
+                JSON_SERIALIZER.decodeFromString<Error>(it)
+            }
             response.close()
-            throw BigBoneRequestException(response)
+            throw BigBoneRequestException(response, error)
         }
     }
 }

--- a/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneRequestException.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/exception/BigBoneRequestException.kt
@@ -1,6 +1,7 @@
 package social.bigbone.api.exception
 
 import okhttp3.Response
+import social.bigbone.api.entity.Error
 
 /**
  * Exception which is thrown when there was a problem executing the associated [social.bigbone.MastodonRequest].
@@ -13,6 +14,12 @@ class BigBoneRequestException : Exception {
     var httpStatusCode = INVALID_STATUS_CODE
 
     /**
+     * If BigBoneRequestException was constructed after an unsuccessful request,
+     * error details as returned by the Mastodon instance might be available here.
+     */
+    var errorDetails: Error? = null
+
+    /**
      * true if [httpStatusCode] contains a valid HTTP Status code, false if not.
      */
     val statusCodeValid: Boolean =
@@ -21,10 +28,12 @@ class BigBoneRequestException : Exception {
     /**
      * Create a BigBoneRequestException using a [Response].
      * @param response an unsuccessful response; the HTTP status message will be used as the detail message for this
-     * exception, HTTP status code will be available via [httpStatusCode].
+     *  exception, HTTP status code will be available via [httpStatusCode]
+     * @param error optionally, an [Error] containing additional details about request errors that led to the unsuccessful response
      */
-    constructor(response: Response) : super(response.message) {
+    constructor(response: Response, error: Error? = null) : super(response.message) {
         httpStatusCode = response.code
+        errorDetails = error
     }
 
     /**


### PR DESCRIPTION
# Description

- parses server response as `Error` in case of unsuccessful request
- adds optional `errorDetails` to `BigBoneRequestException`, making available this data

Fixes #442.

# Type of Change

<!-- Keep the one that applies, remove the rest - including this comment) -->

- New feature

# How Has This Been Tested?

Performing invalid requests against different servers/endpoints, ensuring that error data is returned and properly parsed.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have added KDoc documentation to all public methods

# Optional checks

<!-- The items below are some more things to check before asking other people to review your code.
Please delete any entry that does not apply. If none apply, please also delete this whole section. -->

- [ ] In case you worked on a new feature: Did you also implement the reactive endpoint (bigbone-rx)?
- [ ] In case you added new `*Methods` classes: Did you also reference it in the `MastodonClient` main class?
- [ ] Did you also update the documentation in the `/docs` folder (e.g. API Coverage page)?
