### PR TITLE
Upgrade okhttp to version 5.0.0-alpha.14

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlin = "2.0.21"
 kotlin-coroutines = "1.9.0"
 kotlinx-serialization-json = "1.7.3"
 mockk = "1.13.13"
-okhttp = "4.12.0"
+okhttp = "5.0.0-alpha.14"
 rxjava = "3.1.9"
 
 # Gradle plugins


### PR DESCRIPTION
# Description

According to to https://github.com/square/okhttp/blob/master/CHANGELOG.md, Okhttp 5 is considered safe to use in production settings since version 5.0.0-alpha.12. The document states: "Although this release is labeled alpha, the only unstable thing in it is our new APIs. This release has many critical bug fixes and is safe to run in production."

# Type of Change

- Dependency update / replacement

# Breaking Changes

None.

# How Has This Been Tested?

BigBone code samples executed.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods
