### PR TITLE
Replace deprecated gradle-build-action with setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   build-gradle-project:
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout project sources
         uses: actions/checkout@v4
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Run build with Gradle Wrapper
         run: ./gradlew check jacocoTestReport
       - name: Codecov


### PR DESCRIPTION
# Description

Replaces the deprecated [`gradle-build-action`](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle) with its recommended replacement `setup-gradle´ (which, starting with version 4, also adds [Gradle Wrapper validation](https://github.com/gradle/actions/tree/main/wrapper-validation), which is quite nice!)

# Type of Change

- Dependency update / replacement

# Breaking Changes

- None

# How Has This Been Tested?

I couldn’t test this as it runs on GitHub Actions but I’ve been using the replacement action for months in another project without any issues.

# Mandatory Checklist

- [ ] I ran `gradle check` and there were no errors reported
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods