### PR TITLE
Set preconditions for artifact signing

### DIFF
--- a/buildSrc/src/main/groovy/bigbone.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/bigbone.library-conventions.gradle
@@ -56,6 +56,11 @@ publishing {
 }
 
 signing {
+    required {
+        project.hasProperty("signingKeyId")
+        project.hasProperty("signingKey")
+        project.hasProperty("signingPassword")
+    }
     def signingKeyId = findProperty("signingKeyId")
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")


### PR DESCRIPTION
# Description

This PR fixes an issue where publishing BigBone to a local Maven repository failed because no signing configuration was present. Usually the error appeared when you tried to run one of these Gradle tasks:

- `./gradlew publishBigbonePublicationToMavenLocal`
- `./gradlew publishBigbonePublicationToLocalBuildRepoRepository`

As we do not need signing for local publications, we can safely turn this off using the changes proposed.

# Type of Change

- Bug fix

# Breaking Changes

None.

# How Has This Been Tested?

I ran `./gradlew publishBigbonePublicationToMavenLocal` and `./gradlew publishBigbonePublicationToLocalBuildRepoRepository`. Also the Github build works as expected.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods
