### PR TITLE
Cleanup: remove deprecated MediaAttachment.text_url

### DIFF
--- a/bigbone/src/main/kotlin/social/bigbone/api/entity/MediaAttachment.kt
+++ b/bigbone/src/main/kotlin/social/bigbone/api/entity/MediaAttachment.kt
@@ -42,17 +42,6 @@ data class MediaAttachment(
     val previewUrl: String = "",
 
     /**
-     * A shorter URL for the attachment.
-     */
-    @SerialName("text_url")
-    @Deprecated(
-        message = "Attribute was removed in Mastodon 3.5 and is due for removal in BigBone in 2024.",
-        replaceWith = ReplaceWith("url"),
-        level = DeprecationLevel.WARNING
-    )
-    val textUrl: String? = null,
-
-    /**
      * Metadata returned by Paperclip.
      */
     @SerialName("meta")

--- a/bigbone/src/test/assets/attachment.json
+++ b/bigbone/src/test/assets/attachment.json
@@ -3,6 +3,5 @@
   "type": "video",
   "url": "youtube",
   "remote_url": "remote",
-  "preview_url": "preview",
-  "text_url": "text"
+  "preview_url": "preview"
 }

--- a/bigbone/src/test/assets/media_get_attachment_success.json
+++ b/bigbone/src/test/assets/media_get_attachment_success.json
@@ -4,7 +4,6 @@
   "url": "https://files.mastodon.social/media_attachments/files/022/348/641/original/e96382f26c72a29c.jpeg",
   "preview_url": "https://files.mastodon.social/media_attachments/files/022/348/641/small/e96382f26c72a29c.jpeg",
   "remote_url": null,
-  "text_url": "https://mastodon.social/media/4Zj6ewxzzzDi0g8JnZQ",
   "meta": {
     "focus": {
       "x": -0.42,

--- a/bigbone/src/test/kotlin/social/bigbone/api/entity/MediaAttachmentTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/entity/MediaAttachmentTest.kt
@@ -10,12 +10,11 @@ class MediaAttachmentTest {
     @Test
     fun deserialize() {
         val json = AssetsUtil.readFromAssets("attachment.json")
-        val status: MediaAttachment = JSON_SERIALIZER.decodeFromString(json)
-        status.id shouldBeEqualTo "10"
-        status.url shouldBeEqualTo "youtube"
-        status.remoteUrl shouldNotBe null
-        status.previewUrl shouldBeEqualTo "preview"
-        status.textUrl shouldNotBe null
-        status.type shouldBeEqualTo MediaAttachment.MediaType.VIDEO
+        val mediaAttachment: MediaAttachment = JSON_SERIALIZER.decodeFromString(json)
+        mediaAttachment.id shouldBeEqualTo "10"
+        mediaAttachment.url shouldBeEqualTo "youtube"
+        mediaAttachment.remoteUrl shouldNotBe null
+        mediaAttachment.previewUrl shouldBeEqualTo "preview"
+        mediaAttachment.type shouldBeEqualTo MediaAttachment.MediaType.VIDEO
     }
 }

--- a/bigbone/src/test/kotlin/social/bigbone/api/method/MediaMethodsTest.kt
+++ b/bigbone/src/test/kotlin/social/bigbone/api/method/MediaMethodsTest.kt
@@ -108,7 +108,6 @@ class MediaMethodsTest {
             url shouldBeEqualTo "https://files.mastodon.social/media_attachments/files/022/348/641/original/e96382f26c72a29c.jpeg"
             previewUrl shouldBeEqualTo "https://files.mastodon.social/media_attachments/files/022/348/641/small/e96382f26c72a29c.jpeg"
             remoteUrl.shouldBeNull()
-            textUrl shouldBeEqualTo "https://mastodon.social/media/4Zj6ewxzzzDi0g8JnZQ"
 
             with(meta) {
                 shouldNotBeNull()
@@ -207,7 +206,6 @@ class MediaMethodsTest {
         attachment.url shouldBeEqualTo "youtube"
         attachment.remoteUrl shouldNotBe null
         attachment.previewUrl shouldBeEqualTo "preview"
-        attachment.textUrl shouldNotBe null
     }
 
     @Test


### PR DESCRIPTION
# Description

`MediaAttachment.text_url` has been removed in Mastodon since 3.5.0, see [documentation](https://docs.joinmastodon.org/entities/MediaAttachment/#text_url).

Includes related cleanup of tests.

# Breaking Changes

<!-- A breaking change is a change to supported functionality between released versions of a library that would require 
a customer to do work in order to upgrade to the newer version. If your change includes one or more breaking changes, 
please list/document them here, otherwise set "None". This information will be published in our release notes. -->

- `MediaAttachment.text_url` has been removed after being deprecated with warning for a while. This value has been removed from Mastodon since 3.5.0 and should no longer be relied upon. Use `url` instead.

# How Has This Been Tested?

See below.

# Mandatory Checklist

- [x] I ran `gradle check` and there were no errors reported
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have added KDoc documentation to all public methods

Unmarked do not apply.